### PR TITLE
Fix Airflow DAG module imports with shared loader

### DIFF
--- a/dags/topic_classifier_pipeline_dag.py
+++ b/dags/topic_classifier_pipeline_dag.py
@@ -1,0 +1,100 @@
+"""Airflow DAG for running the rule-based topic classifier pipeline."""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+from airflow import DAG
+from airflow.decorators import task
+from airflow.exceptions import AirflowFailException
+from airflow.models import Variable
+
+from dags.utils.module_loader import load_module_main
+
+classifier_main = load_module_main(__file__, "pipeline.topic_classifier")
+
+
+def _parse_list_variable(key: str) -> List[str]:
+    raw_value = Variable.get(key, default_var="")
+    if not raw_value:
+        return []
+    return [item.strip() for item in raw_value.split(",") if item.strip()]
+
+
+def _parse_bool_variable(key: str) -> bool:
+    raw_value = Variable.get(key, default_var="").strip().lower()
+    if not raw_value:
+        return False
+    return raw_value in {"1", "true", "t", "yes", "y"}
+
+
+def _parse_int_variable(key: str) -> Optional[int]:
+    raw_value = Variable.get(key, default_var="").strip()
+    if not raw_value:
+        return None
+    try:
+        return int(raw_value)
+    except ValueError as exc:
+        raise AirflowFailException(f"Variable {key!r} must be an integer, got: {raw_value!r}") from exc
+
+
+default_args = {
+    "owner": "data-team",
+    "depends_on_past": False,
+    "email_on_failure": True,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=10),
+}
+
+
+with DAG(
+    dag_id="topic_classifier_pipeline",
+    description="Run topic classifier and persist assignments to ClickHouse.",
+    default_args=default_args,
+    schedule_interval=timedelta(days=1),
+    start_date=datetime(2025, 1, 1),
+    catchup=False,
+    tags=["topics", "clickhouse", "classification"],
+) as dag:
+
+    @task(task_id="run_topic_classifier")
+    def run_topic_classifier() -> None:
+        logger = logging.getLogger("topic_classifier_pipeline_dag")
+
+        log_level = Variable.get("TOPIC_CLASSIFIER_LOG_LEVEL", default_var="INFO").strip() or "INFO"
+        args: List[str] = ["--log-level", log_level.upper()]
+
+        taxonomy_path = Variable.get("TOPIC_CLASSIFIER_TAXONOMY", default_var="").strip()
+        if taxonomy_path:
+            args.extend(["--taxonomy", taxonomy_path])
+            logger.info("Using taxonomy file: %s", taxonomy_path)
+
+        sources = _parse_list_variable("TOPIC_CLASSIFIER_SOURCES")
+        if sources:
+            args.append("--sources")
+            args.extend(sources)
+            logger.info("Restricting classifier to sources: %s", sources)
+
+        since = Variable.get("TOPIC_CLASSIFIER_SINCE", default_var="").strip()
+        if since:
+            args.extend(["--since", since])
+            logger.info("Processing datasets updated since: %s", since)
+
+        limit_value = _parse_int_variable("TOPIC_CLASSIFIER_LIMIT")
+        if limit_value is not None:
+            args.extend(["--limit", str(limit_value)])
+            logger.info("Limiting classifier to %d datasets", limit_value)
+
+        if _parse_bool_variable("TOPIC_CLASSIFIER_DRY_RUN"):
+            args.append("--dry-run")
+            logger.info("Running classifier in dry-run mode")
+
+        logger.info("Invoking topic classifier CLI with args: %s", args)
+        result = classifier_main(args)
+        if result != 0:
+            raise AirflowFailException(f"Topic classifier CLI exited with {result}")
+
+    run_topic_classifier()

--- a/dags/topic_selected_ingest_dag.py
+++ b/dags/topic_selected_ingest_dag.py
@@ -1,4 +1,3 @@
-import sys
 import logging
 from datetime import datetime, timedelta
 from typing import List
@@ -8,9 +7,9 @@ from airflow.decorators import task
 from airflow.exceptions import AirflowFailException
 from airflow.models import Variable
 
-sys.path.append("/opt/airflow")
+from dags.utils.module_loader import load_module_main
 
-from pipeline.topic_selected_ingest import main as ingest_main  # noqa: E402
+ingest_main = load_module_main(__file__, "pipeline.topic_selected_ingest")
 
 
 default_args = {

--- a/dags/utils/__init__.py
+++ b/dags/utils/__init__.py
@@ -1,0 +1,5 @@
+"""Utility helpers shared by Airflow DAG definitions."""
+
+from .module_loader import load_module_main
+
+__all__ = ["load_module_main"]

--- a/dags/utils/module_loader.py
+++ b/dags/utils/module_loader.py
@@ -1,0 +1,156 @@
+"""Helpers for dynamically loading project modules from Airflow DAGs."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Callable, Iterable, Iterator, Optional, Sequence, Tuple, Union, cast
+
+LOGGER = logging.getLogger(__name__)
+
+PathLike = Union[str, os.PathLike[str]]
+MainCallable = Callable[[Optional[Sequence[str]]], int]
+
+
+def _resolve_path(value: PathLike) -> Path:
+    path = Path(value)
+    try:
+        return path.resolve(strict=False)
+    except FileNotFoundError:
+        return path.absolute()
+
+
+def _gather_base_candidates(dag_file: PathLike) -> Sequence[Path]:
+    dag_path = _resolve_path(dag_file)
+    dag_dir = dag_path if dag_path.is_dir() else dag_path.parent
+
+    candidates = [dag_dir]
+    candidates.extend(parent for parent in dag_dir.parents)
+
+    for env_name in ("AIRFLOW_HOME", "PIPELINE_HOME"):
+        env_value = os.environ.get(env_name)
+        if not env_value:
+            continue
+        env_path = _resolve_path(env_value)
+        candidates.append(env_path)
+        parent = env_path.parent
+        if parent != env_path:
+            candidates.append(parent)
+
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        candidate_path = _resolve_path(candidate)
+        if not candidate_path.exists() or not candidate_path.is_dir():
+            continue
+        key = str(candidate_path)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(candidate_path)
+    return unique
+
+
+def _iter_search_roots(dag_file: PathLike) -> Iterator[Path]:
+    seen: set[str] = set()
+    for base in _gather_base_candidates(dag_file):
+        key = str(base)
+        if key not in seen:
+            seen.add(key)
+            yield base
+        try:
+            for child in base.iterdir():
+                if not child.is_dir():
+                    continue
+                child_key = str(child.resolve(strict=False))
+                if child_key in seen:
+                    continue
+                seen.add(child_key)
+                yield child.resolve(strict=False)
+        except (OSError, PermissionError):
+            LOGGER.debug("Skipping directory traversal for %s due to access error", base)
+            continue
+
+
+def _candidate_module_path(root: Path, module_parts: Sequence[str]) -> Optional[Tuple[Path, Path]]:
+    """Return the module path and sys.path root if the module exists below ``root``."""
+
+    candidate_parts: Iterable[Sequence[str]] = [module_parts]
+    if module_parts and root.name == module_parts[0]:
+        candidate_parts = [module_parts, module_parts[1:]]
+
+    for parts in candidate_parts:
+        if not parts:
+            continue
+        module_file = root.joinpath(*parts[:-1], f"{parts[-1]}.py")
+        if module_file.is_file():
+            sys_path_root = root
+            prefix_length = len(module_parts) - len(parts)
+            for _ in range(prefix_length):
+                sys_path_root = sys_path_root.parent
+            return module_file, sys_path_root
+        package_init = root.joinpath(*parts, "__init__.py")
+        if package_init.is_file():
+            sys_path_root = root
+            prefix_length = len(module_parts) - len(parts)
+            for _ in range(prefix_length):
+                sys_path_root = sys_path_root.parent
+            return package_init, sys_path_root
+    return None
+
+
+def _import_module(module_name: str, dag_file: PathLike) -> ModuleType:
+    module_parts = module_name.split(".")
+
+    try:
+        return importlib.import_module(module_name)
+    except ModuleNotFoundError as exc:
+        if exc.name != module_name:
+            raise
+
+    for search_root in _iter_search_roots(dag_file):
+        candidate = _candidate_module_path(search_root, module_parts)
+        if not candidate:
+            continue
+        module_path, sys_path_root = candidate
+        sys_path_entry = str(sys_path_root)
+        if sys_path_entry not in sys.path:
+            sys.path.insert(0, sys_path_entry)
+            LOGGER.debug("Added %s to sys.path while loading %s", sys_path_entry, module_name)
+        try:
+            module = importlib.import_module(module_name)
+            return module
+        except ModuleNotFoundError as exc:
+            if exc.name != module_name:
+                raise
+            LOGGER.debug("Module %s still not found after adding %s", module_name, sys_path_entry)
+            continue
+    raise ModuleNotFoundError(
+        f"Cannot locate module '{module_name}' relative to DAG '{dag_file}'."
+    )
+
+
+def load_module_main(dag_file: PathLike, module_name: str, attribute: str = "main") -> MainCallable:
+    """Return the callable ``attribute`` from ``module_name`` located near ``dag_file``.
+
+    The loader inspects the DAG's directory, its parents, ``$AIRFLOW_HOME``,
+    optional ``$PIPELINE_HOME``, and their immediate subdirectories to find the
+    requested module. Once located, the module is imported and the callable
+    attribute (``main`` by default) is returned.
+    """
+
+    module = _import_module(module_name, dag_file)
+
+    try:
+        main_callable = getattr(module, attribute)
+    except AttributeError as exc:
+        raise AttributeError(f"Module '{module_name}' does not define '{attribute}'") from exc
+
+    if not callable(main_callable):
+        raise TypeError(f"Attribute '{attribute}' on module '{module_name}' is not callable")
+
+    return cast(MainCallable, main_callable)


### PR DESCRIPTION
## Summary
- add a reusable module loader for DAGs to locate project packages when deployed in Airflow
- update the topic-selected ingestion DAG to use the loader
- add a topic classifier pipeline DAG that resolves the CLI via the shared loader

## Testing
- python -m compileall dags

------
https://chatgpt.com/codex/tasks/task_e_68f7e22d0e588329ba32bc5af9dbf067