### PR TITLE
Fix attribute workflow: grant id-token:write for OIDC

### DIFF
--- a/.github/workflows/attribute.yml
+++ b/.github/workflows/attribute.yml
@@ -28,6 +28,10 @@ jobs:
   attribute:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # claude-code-action authenticates GitHub via OIDC — needs id-token: write.
+    permissions:
+      contents: read
+      id-token: write
     env:
       POSTGRES_URL: ${{ secrets.SCRAPER_POSTGRES_URL }}
     steps:


### PR DESCRIPTION
The `scheduled-attribute` job failed at startup with `Could not fetch an OIDC token` because the job lacked `id-token: write`. The DB connection and the subscription OAuth token both worked — this permission was the only blocker.

Adds:
```yaml
permissions:
  contents: read
  id-token: write
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_