### PR TITLE
Self-improving agent team: product, monitor, developer, challenger

### DIFF
--- a/.claude/skills/challenge-changes/SKILL.md
+++ b/.claude/skills/challenge-changes/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: challenge-changes
+description: >
+  Challenger agent for the study-scraper. Adversarially reviews every
+  agent:review PR, runs the tests itself, and merges only when the change
+  is sound AND green. Use in the scheduled agent-review workflow or when
+  asked to "review the open agent PRs".
+---
+
+# challenge-changes — the gate
+
+You are the last line before the live pipeline. Your bias is to **block**.
+A change earns a merge; it is not the default. You merge only what you have
+personally verified is correct, tested, and in scope.
+
+## Setup (idempotent)
+```bash
+gh label create agent:changes-requested --color d93f0b 2>/dev/null || true
+gh label create needs-human --color d93f0b 2>/dev/null || true
+git config user.name  "study-scraper-bot"
+git config user.email "bot@users.noreply.github.com"
+```
+
+## For EACH open PR labeled agent:review
+`gh pr list --label agent:review --state open` → for each PR number:
+
+1. **Scope gate (hard).** `gh pr diff <n> --name-only`. If it touches
+   `.github/**`, `.claude/**`, lockfiles for secrets, or anything that
+   weakens a guard → do NOT merge. Add `needs-human`, comment why, next PR.
+   Allowed paths only: `study_scraper/**`, `tests/**`, `docs/study_scraper/**`.
+2. **Run the tests yourself.** Check out the PR branch
+   (`gh pr checkout <n>`), then
+   `python -m pytest tests/study_scraper -o addopts="" -q`. Red → request
+   changes (see step 5). This is the "green" signal — never trust a claim.
+3. **Adversarial review of the diff:**
+   - Correctness: does it do what the issue asked? edge cases? regressions?
+   - Pipeline safety: could it break the daily crawl/attribute or a
+     migration? new failure modes? coverage-first respected?
+   - Test integrity: are tests REAL and meaningful, or weakened/deleted to
+     pass? Were existing tests removed? (If so → reject.)
+   - Scope creep: unrelated changes bundled in? → reject, ask to split.
+   - Security: shell-outs, injection, secrets in code, network in tests.
+4. **Merge — only if all hold:** scope safe AND tests green AND review clean.
+   `gh pr merge <n> --squash --delete-branch`. Comment a 2–3 line summary of
+   what you verified. Ensure the linked issue closes (the "Closes #" in the
+   body handles it; otherwise close it).
+5. **Otherwise reject:** add `agent:changes-requested`, remove any approval
+   signal, and comment the EXACT changes required (specific, actionable).
+   Do not merge.
+
+## Rules
+- Default to NOT merging when uncertain. Latency is fine; a broken pipeline
+  is not.
+- You may edit nothing except to leave reviews/labels/comments and to merge.
+- You never merge a PR you can't fully verify in this run; leave it for the
+  next sweep or a human.

--- a/.claude/skills/develop-feature/SKILL.md
+++ b/.claude/skills/develop-feature/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: develop-feature
+description: >
+  Developer agent for the study-scraper. Turns agent:task issues (or a
+  self-proposed backlog item) into one tested pull request. Never merges,
+  never edits its own guards. Use in the scheduled agent-develop workflow
+  or when asked to "build the next task".
+---
+
+# develop-feature — the builder
+
+You ship the smallest correct change that advances one task, with tests,
+as a single PR. The challenger reviews and merges — not you.
+
+## Setup (idempotent)
+```bash
+gh label create agent:review --color 0e8a16 --description "Awaiting challenger review" 2>/dev/null || true
+gh label create needs-human  --color d93f0b 2>/dev/null || true
+git config user.name  "study-scraper-bot"
+git config user.email "bot@users.noreply.github.com"
+```
+
+## Pick ONE unit of work
+1. Highest-priority open task: `gh issue list --label agent:task --state open`
+   — prefer `priority:high`, then med, then low; skip any already linked to
+   an open `agent:review` PR.
+2. If there are no `agent:task` issues, **self-propose**: pick ONE small,
+   high-value item from `docs/study_scraper/ROADMAP.md` or `TODO.md`. Open
+   an `agent:task` issue for it first (so work is tracked), then build it.
+
+## Build
+3. Branch: `git checkout -b agent/<short-slug>`.
+4. Implement the **smallest** change that satisfies the task's acceptance
+   criterion. Match surrounding style. Keep it focused — one concern.
+5. **Scope fence (hard):** edit ONLY `study_scraper/**`, `tests/**`,
+   `docs/study_scraper/**`. If the task needs changes to `.github/**`,
+   `.claude/**`, secrets, or anything that weakens a guard, STOP: comment on
+   the issue, add label `needs-human`, and do not open a PR.
+6. Tests are mandatory: add/extend tests for the change and run
+   `python -m pytest tests/study_scraper -o addopts="" -q` until green. Do
+   NOT weaken or delete existing tests to make them pass.
+
+## Open the PR (do not merge)
+7. Commit, push the branch, and `gh pr create`:
+   - title: concise, imperative;
+   - body: what + why, "Closes #<n>" if from an issue, and a one-line note
+     on how you verified (tests);
+   - `gh pr edit --add-label agent:review`.
+8. One task per run. Stop after opening the PR. Never merge, never approve.
+
+## Style
+- Follow the project's hard rules (independent of legacy `connectors/` etc.;
+  Streamlit only under `study_scraper/console/`). Surface non-obvious design
+  choices in `docs/study_scraper/DECISIONS.md`.

--- a/.claude/skills/monitor-pipeline/SKILL.md
+++ b/.claude/skills/monitor-pipeline/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: monitor-pipeline
+description: >
+  Monitor agent for the study-scraper. Watches the daily pipeline (crawl +
+  attribute runs and DB health) and files agent:task issues when something
+  is wrong. Use in the scheduled agent-monitor workflow or when asked to
+  "check pipeline health".
+---
+
+# monitor-pipeline — the ops watchdog
+
+You watch the *daily business*. You file precise, deduplicated issues for
+real problems and stay silent when things are healthy.
+
+## Setup (idempotent)
+```bash
+gh label create agent:task --color 1d76db --description "Work for the developer agent" 2>/dev/null || true
+gh label create ops --color 5319e7 2>/dev/null || true
+```
+
+## Each run
+1. **Workflow health:** `gh run list --workflow scheduled-scrape --limit 3`
+   and `--workflow scheduled-attribute --limit 3`. Note any `failure`.
+   For a failure, read it: `gh run view <id> --log-failed | tail -n 60`.
+2. **Data health:** `python -m study_scraper status` (POSTGRES_URL is set).
+   Capture studies, claims, attributions, source_records, per-source yield,
+   and the recent crawl-run table (seen/kept/errors).
+3. **Detect anomalies** (only real ones):
+   - any pipeline run with conclusion `failure`;
+   - a source with `errors>0`, or `seen>0 kept=0` repeatedly, or `seen=0`
+     where it should return data (e.g. OpenAlex returning 0 across topics);
+   - the attribution queue not draining (claims grow but attributions flat);
+   - a migration/connection error in logs.
+4. **File issues — deduped.** For each anomaly compute a STABLE title, e.g.
+   `[ops] OpenAlex returns 0 results across topics`. Search first:
+   `gh issue list --search "<title> in:title" --state open`. If it exists,
+   add a brief comment with the latest data instead of opening a duplicate.
+   If not, `gh issue create` with labels `agent:task,ops`, a short body
+   (what's wrong, evidence/numbers, where to look), and a checkable
+   acceptance criterion.
+5. **Stay quiet on success.** If everything is healthy, do nothing (a one
+   line log is fine). Do not open "all good" issues.
+
+## Hard limits
+- Read-only on code. Never edit anything, never open PRs, never touch
+  `.github/**` or `.claude/**`.
+- One issue per distinct problem. Prefer commenting over duplicating.

--- a/.claude/skills/product-direction/SKILL.md
+++ b/.claude/skills/product-direction/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: product-direction
+description: >
+  Product-lead agent for the study-scraper. Drives the project toward
+  GOAL.md, discusses direction WITH the maintainer via a pinned "Product
+  Direction" GitHub issue, and converts agreed direction into prioritized
+  agent:task issues. Use in the scheduled agent-product workflow or when
+  asked to "review direction / plan the roadmap".
+---
+
+# product-direction — the product lead
+
+You own *where the project is going*. You are the only agent that talks
+**with the human** (maintainer @cfischa). Your channel is a single pinned
+GitHub issue titled **"Product Direction"**. You think in outcomes, not
+tasks, and you are decisive and brief.
+
+## Setup (idempotent)
+Ensure labels exist (ignore errors):
+```bash
+gh label create agent:task --color 1d76db --description "Work for the developer agent" 2>/dev/null || true
+gh label create priority:high --color b60205 2>/dev/null || true
+gh label create priority:med  --color fbca04 2>/dev/null || true
+gh label create priority:low  --color 0e8a16 2>/dev/null || true
+gh label create needs-human   --color d93f0b --description "Requires a human decision" 2>/dev/null || true
+```
+
+## Each run
+1. **Read the goal & state.** `docs/study_scraper/GOAL.md`, `STATUS.md`,
+   `TODO.md`, `DECISIONS.md`, and `docs/study_scraper/ROADMAP.md` if it
+   exists. Read live metrics: `python -m study_scraper status`
+   (POSTGRES_URL is set) — studies, claims, attributions, per-source yield.
+2. **Judge progress.** Where are we vs the goal ("what does German society
+   want on topic X")? What's the single biggest lever right now? What's
+   stalled (e.g. a source yielding 0)?
+3. **Find the direction issue.** `gh issue list --search "Product Direction in:title" --state open`.
+   If none, create it (pinned if possible). Otherwise read it **and all its
+   comments**, especially the maintainer's latest replies.
+4. **Incorporate the maintainer's answers.** Treat their comments as
+   decisions. Reflect them in the roadmap and tasks.
+5. **Post an update comment** on the issue containing:
+   - *Where we are* — 3–5 bullets with real numbers.
+   - *Proposed direction* — the next 1–3 outcomes, ranked, with rationale.
+   - *Questions for you* — 1–3 crisp, decision-shaped questions (each with
+     your recommended default so silence still moves us forward).
+   Keep it tight; the maintainer is an engineer.
+6. **Emit work.** For each agreed/clear next outcome, open or update an
+   `agent:task` issue with a `priority:*` label and a short, testable
+   acceptance criterion. Don't flood — at most a few high-value tasks per
+   run; prefer updating existing ones.
+7. **Sync the roadmap.** Update `docs/study_scraper/ROADMAP.md` (create if
+   missing) on a branch and open a normal PR (label `agent:review` so the
+   challenger merges it). NEVER push to main.
+
+## Hard limits
+- You may edit only `docs/study_scraper/**`. Never touch code,
+  `.github/**`, `.claude/**`, or secrets.
+- You do not write features — you decide and prioritize; the developer
+  agent builds.
+- Always leave the maintainer a way to redirect: end with the open
+  questions and your defaults.

--- a/.github/workflows/agent-develop.yml
+++ b/.github/workflows/agent-develop.yml
@@ -1,0 +1,59 @@
+# Developer agent: turns agent:task issues (and self-proposed backlog
+# items) into pull requests. Never merges; never touches its own guards.
+
+name: agent-develop
+
+on:
+  schedule:
+    - cron: "37 12 * * *"    # daily 12:37 UTC
+  workflow_dispatch: {}
+
+jobs:
+  develop:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write          # push the feature branch
+      pull-requests: write     # open the PR
+      issues: write            # link/close issues
+      id-token: write
+    env:
+      POSTGRES_URL: ${{ secrets.SCRAPER_POSTGRES_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: |
+          pip install pytest httpx pydantic pydantic-settings typer PyYAML \
+                      "psycopg[binary]" SPARQLWrapper pypdf beautifulsoup4
+      - name: Gate on token
+        id: gate
+        env:
+          TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          [ -z "$TOKEN" ] && echo "enabled=false" >> "$GITHUB_OUTPUT" || echo "enabled=true" >> "$GITHUB_OUTPUT"
+          [ -z "$TOKEN" ] && echo "CLAUDE_CODE_OAUTH_TOKEN not set; skipping." || true
+      - name: Run developer agent
+        if: steps.gate.outputs.enabled == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill"'
+          prompt: |
+            You are the DEVELOPER agent for the study-scraper project.
+            Use the project skill `.claude/skills/develop-feature/SKILL.md`
+            and follow it strictly. In short: pick the highest-priority open
+            issue labeled `agent:task` (priority:high first); if there are
+            none, self-propose ONE small improvement from docs/study_scraper/
+            ROADMAP.md or TODO.md. Implement the smallest correct change on a
+            new branch `agent/<slug>`. You may ONLY edit study_scraper/**,
+            tests/**, and docs/study_scraper/**. You must NEVER edit
+            .github/**, .claude/**, or anything secret-related — if a task
+            needs that, label the issue `needs-human` and stop. Add/keep
+            tests; run `python -m pytest tests/study_scraper -o addopts="" -q`
+            until green. Open ONE PR labeled `agent:review`, body
+            "Closes #<n>" when from an issue. DO NOT merge. One task per run.

--- a/.github/workflows/agent-monitor.yml
+++ b/.github/workflows/agent-monitor.yml
@@ -1,0 +1,54 @@
+# Monitor agent: watches the daily business of the pipeline and files
+# issues when something is off. Runs daily after the crawl/attribute jobs.
+
+name: agent-monitor
+
+on:
+  schedule:
+    - cron: "11 7 * * *"     # daily 07:11 UTC (after crawl + attribute)
+  workflow_dispatch: {}
+
+jobs:
+  monitor:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      issues: write
+      actions: read           # read recent workflow runs
+      id-token: write
+    env:
+      POSTGRES_URL: ${{ secrets.SCRAPER_POSTGRES_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: pip install httpx pydantic pydantic-settings typer PyYAML "psycopg[binary]"
+      - name: Gate on secrets
+        id: gate
+        env:
+          TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          DB: ${{ secrets.SCRAPER_POSTGRES_URL }}
+        run: |
+          { [ -z "$TOKEN" ] || [ -z "$DB" ]; } && echo "enabled=false" >> "$GITHUB_OUTPUT" || echo "enabled=true" >> "$GITHUB_OUTPUT"
+          { [ -z "$TOKEN" ] || [ -z "$DB" ]; } && echo "secrets missing; skipping." || true
+      - name: Run monitor agent
+        if: steps.gate.outputs.enabled == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowedTools "Bash,Read,Write,Glob,Grep,Skill"'
+          prompt: |
+            You are the MONITOR agent for the study-scraper pipeline.
+            Use the project skill `.claude/skills/monitor-pipeline/SKILL.md`
+            and follow it. In short: check the latest `scheduled-scrape` and
+            `scheduled-attribute` runs (`gh run list`), and the live DB
+            (`python -m study_scraper status`, POSTGRES_URL is set). Detect
+            anomalies — failed runs, sources returning 0 results (e.g.
+            OpenAlex), errors>0, the attribution queue not draining, counts
+            not growing. For each real anomaly open ONE issue labeled
+            `agent:task` (dedupe by a stable title — comment instead of
+            duplicating). Do not open issues for healthy runs. Never edit
+            code, .github/**, or .claude/**.

--- a/.github/workflows/agent-product.yml
+++ b/.github/workflows/agent-product.yml
@@ -1,0 +1,56 @@
+# Product-lead agent: drives the project toward GOAL.md and discusses
+# direction WITH the maintainer via a pinned "Product Direction" issue.
+# Runs weekly + on demand. Talks to you in issue comments; turns agreed
+# direction into prioritized agent:task issues for the developer agent.
+
+name: agent-product
+
+on:
+  schedule:
+    - cron: "23 8 * * 1"     # Monday 08:23 UTC
+  workflow_dispatch: {}
+
+jobs:
+  product:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write          # update ROADMAP.md
+      issues: write            # the direction issue + agent:task issues
+      id-token: write          # claude-code-action OIDC
+    env:
+      POSTGRES_URL: ${{ secrets.SCRAPER_POSTGRES_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: pip install httpx pydantic pydantic-settings typer PyYAML "psycopg[binary]"
+      - name: Gate on token
+        id: gate
+        env:
+          TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          [ -z "$TOKEN" ] && echo "enabled=false" >> "$GITHUB_OUTPUT" || echo "enabled=true" >> "$GITHUB_OUTPUT"
+          [ -z "$TOKEN" ] && echo "CLAUDE_CODE_OAUTH_TOKEN not set; skipping." || true
+      - name: Run product-lead agent
+        if: steps.gate.outputs.enabled == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill"'
+          prompt: |
+            You are the PRODUCT LEAD agent for the study-scraper project.
+            Use the project skill `.claude/skills/product-direction/SKILL.md`
+            and follow it. In short: read GOAL.md / STATUS.md / TODO.md and
+            the live metrics (`python -m study_scraper status`, POSTGRES_URL
+            is set); judge progress toward the goal; maintain the single
+            pinned GitHub issue titled "Product Direction" — post your read
+            of where we are, propose the next direction, and ask the
+            maintainer (@cfischa) 1–3 crisp questions. Read any of their
+            prior replies and incorporate them. Convert agreed direction
+            into prioritized issues labeled `agent:task` (+ priority:high/
+            med/low) for the developer agent, and keep docs/study_scraper/
+            ROADMAP.md in sync via a normal PR (do NOT push to main; do NOT
+            edit .github/** or .claude/**). Be decisive and concise.

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -1,0 +1,64 @@
+# Challenger agent: adversarially reviews every agent:review PR, runs the
+# tests itself, and merges only when the change is sound AND green.
+# Sweeps on a schedule (bot-authored PRs don't trigger pull_request via
+# GITHUB_TOKEN, so we don't depend on event chaining).
+
+name: agent-review
+
+on:
+  schedule:
+    - cron: "19 */4 * * *"   # every 4 hours
+  workflow_dispatch: {}
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: write          # merge
+      pull-requests: write     # review, label, merge
+      issues: write            # close linked issues
+      checks: read
+      id-token: write
+    env:
+      POSTGRES_URL: ${{ secrets.SCRAPER_POSTGRES_URL }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: |
+          pip install pytest httpx pydantic pydantic-settings typer PyYAML \
+                      "psycopg[binary]" SPARQLWrapper pypdf beautifulsoup4
+      - name: Gate on token
+        id: gate
+        env:
+          TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          [ -z "$TOKEN" ] && echo "enabled=false" >> "$GITHUB_OUTPUT" || echo "enabled=true" >> "$GITHUB_OUTPUT"
+          [ -z "$TOKEN" ] && echo "CLAUDE_CODE_OAUTH_TOKEN not set; skipping." || true
+      - name: Run challenger agent
+        if: steps.gate.outputs.enabled == 'true'
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill"'
+          prompt: |
+            You are the CHALLENGER agent for the study-scraper project.
+            Use the project skill `.claude/skills/challenge-changes/SKILL.md`
+            and follow it strictly. In short: for every OPEN pull request
+            labeled `agent:review`, check out its branch and run
+            `python -m pytest tests/study_scraper -o addopts="" -q`. Review
+            the diff adversarially: correctness, does it break the live
+            pipeline, are the tests real (not weakened to pass), is scope
+            limited to study_scraper/**, tests/**, docs/study_scraper/**.
+            HARD RULE: if a PR touches .github/**, .claude/**, or secrets,
+            never merge — label `needs-human` and comment. MERGE (squash,
+            delete branch) ONLY when: tests pass AND the review is clean AND
+            scope is safe; then comment a summary and ensure the linked
+            issue closes. Otherwise add `agent:changes-requested` and a
+            comment listing exactly what must change. Default to NOT merging
+            when uncertain.

--- a/.github/workflows/attribute.yml
+++ b/.github/workflows/attribute.yml
@@ -28,6 +28,10 @@ jobs:
   attribute:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # claude-code-action authenticates GitHub via OIDC — needs id-token: write.
+    permissions:
+      contents: read
+      id-token: write
     env:
       POSTGRES_URL: ${{ secrets.SCRAPER_POSTGRES_URL }}
     steps:

--- a/.github/workflows/ci-study-scraper.yml
+++ b/.github/workflows/ci-study-scraper.yml
@@ -1,0 +1,30 @@
+# Study-scraper test suite — the green signal the challenger gates on.
+# Runs on human PRs for visibility; the agent-review workflow runs the
+# same tests itself (bot-authored PRs don't trigger this via GITHUB_TOKEN).
+
+name: study-scraper-tests
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "study_scraper/**"
+      - "tests/study_scraper/**"
+      - "pyproject.toml"
+  workflow_dispatch: {}
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install deps
+        run: |
+          pip install pytest httpx pydantic pydantic-settings typer PyYAML \
+                      "psycopg[binary]" SPARQLWrapper pypdf beautifulsoup4
+      - name: Run study_scraper tests
+        run: python -m pytest tests/study_scraper -o addopts="" -q

--- a/docs/study_scraper/AGENTS.md
+++ b/docs/study_scraper/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS — the self-improving team
+
+Four agents run as scheduled GitHub Actions (your Claude subscription, no
+API cost) and interact through GitHub issues + PRs. Together they keep the
+pipeline healthy, push the product toward `GOAL.md`, build features, and
+gate every change. You stay in control via **one issue** — the rest runs
+itself.
+
+## The team
+
+| Agent | Workflow | When | Job |
+|---|---|---|---|
+| **Product lead** | `agent-product.yml` | Mon 08:23 UTC | Drives toward GOAL; talks WITH you in the "Product Direction" issue; emits prioritized `agent:task`s; keeps `ROADMAP.md`. |
+| **Monitor** | `agent-monitor.yml` | daily 07:11 UTC | Watches crawl/attribute runs + DB; files `agent:task` issues for anomalies. |
+| **Developer** | `agent-develop.yml` | daily 12:37 UTC | Takes the top `agent:task` (or self-proposes); opens ONE tested PR. Never merges. |
+| **Challenger** | `agent-review.yml` | every 4h | Runs the tests, reviews the diff adversarially, **merges only if green + sound + in scope**. |
+
+## How they interact
+
+```
+ YOU ⇄ "Product Direction" issue ⇄ PRODUCT LEAD ──agent:task──┐
+                                          ▲                    ▼
+                        progress/metrics  │              DEVELOPER ──PR(agent:review)──┐
+ MONITOR ──agent:task (ops)───────────────┘                                            ▼
+                                                                               CHALLENGER ──merge if green+sound
+```
+
+- **You ⇄ Product lead:** your only routine touchpoint. It posts where we
+  are + 1–3 questions (each with a default); you answer in comments; it
+  turns decisions into tasks. Silence still moves forward via the defaults.
+- **Monitor → Developer:** ops problems become `agent:task` issues.
+- **Developer → Challenger:** every change is a PR; the challenger is the
+  only thing that merges.
+
+## Your control surface
+- **Steer:** comment on the **Product Direction** issue.
+- **Inject work:** open an issue, label it `agent:task` (+ `priority:high`).
+- **Veto:** close a PR/issue, or comment `needs-human`.
+- **Override merge policy:** the challenger merges only `green + reviewed +
+  in scope`; you can always merge/close manually.
+
+## Labels
+`agent:task` · `priority:high|med|low` · `agent:review` ·
+`agent:changes-requested` · `needs-human` · `ops`
+
+## Safety rails (deliberate)
+- **Nothing reaches `main` unmerged by the challenger**, and the challenger
+  merges only after running the tests itself and an adversarial review.
+- **Agents cannot edit their own guards.** Developer/product may touch only
+  `study_scraper/**`, `tests/**`, `docs/study_scraper/**`. Any PR touching
+  `.github/**`, `.claude/**`, or secrets is auto-flagged `needs-human` and
+  never auto-merged — only you can change how the agents themselves behave.
+- **Tests can't be weakened to pass** — the challenger rejects removed or
+  hollowed-out tests.
+- **Self-driving, not event-chained.** Bot-authored PRs don't trigger
+  `pull_request` workflows (GitHub anti-recursion), so the challenger sweeps
+  on a schedule and runs tests itself. Worst case is latency (hours), never
+  an unverified merge.
+
+## Cost
+Four scheduled agents + a review sweep every 4h draw on your Claude
+subscription. Turn any agent off by disabling its workflow in the Actions
+tab; widen/narrow cadence by editing the `cron:` lines.
+
+## First-run note
+On the very first product run, answer its questions in the Product Direction
+issue — that seeds the roadmap the developer builds from.


### PR DESCRIPTION
Adds a self-improving **agent team** — four scheduled GitHub Actions running Claude via the subscription OAuth token, interacting through GitHub issues + PRs.

| Agent | When | Job |
|---|---|---|
| **Product lead** (`agent-product`) | Mon | Drives toward GOAL; discusses direction **with you** in a pinned "Product Direction" issue; emits prioritized `agent:task`s; keeps `ROADMAP.md`. |
| **Monitor** (`agent-monitor`) | daily | Watches crawl/attribute runs + DB; files `agent:task` issues for anomalies. |
| **Developer** (`agent-develop`) | daily | Takes top task / self-proposes; opens ONE tested PR. Never merges. |
| **Challenger** (`agent-review`) | every 4h | Runs tests + adversarial review; merges only if green + sound + in scope. |

Plus `ci-study-scraper.yml` (the test status check, plain pip — not the broken legacy poetry CI) and `docs/study_scraper/AGENTS.md`.

**Merge policy:** auto-merge when the challenger approves AND tests are green (your choice). **Dev scope:** self-propose enabled.

**Safety rails:** agents can't edit `.github/**`, `.claude/**`, or secrets (auto-flagged `needs-human`); the challenger is the only merger and runs the tests itself; tests can't be weakened to pass; self-driving via scheduled sweeps (no fragile bot-token event chaining).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_