### PR TITLE
Dock: Attributions + Sources pages

### DIFF
--- a/study_scraper/console/pages/4_Attributions.py
+++ b/study_scraper/console/pages/4_Attributions.py
@@ -1,0 +1,91 @@
+"""Attributions browser — the answer layer (A21).
+
+Browse and filter the structured `(question, position, percentage)`
+triples the llm-v1 extractor produced from study claims. This is the
+human view of "what does German society think about X": filter by topic,
+position, or free text; sort by percentage; click through to the source.
+
+Read-only. Lake (source_record) attributions are not shown here yet —
+this page joins study-backed attributions only.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from study_scraper.console._shared import storage_or_error
+
+
+st.set_page_config(page_title="Study scraper — attributions", layout="wide")
+st.title("Attributions — structured findings")
+st.caption(
+    "Each row is a (question, position, percentage) triple extracted by "
+    "`llm-v1` from a study's claims. Filter and sort to answer "
+    "'what share supports / opposes X?'."
+)
+
+storage = storage_or_error()
+if storage is None:
+    st.stop()
+
+total = storage.count_attributions()
+st.metric("attributions stored", total)
+if total == 0:
+    st.info(
+        "No attributions yet. Run the attribution pass: "
+        "`python -m study_scraper attribute` (live) or the offline "
+        "`attribute-prompts` → `attribute-apply` path."
+    )
+    st.stop()
+
+topics = storage.list_distinct_attribution_topics()
+
+col_a, col_b, col_c = st.columns([2, 1, 1])
+with col_a:
+    query = st.text_input("search question text", value="")
+with col_b:
+    position = st.selectbox(
+        "position", ["(all)", "support", "oppose", "neutral", "unspecified"]
+    )
+with col_c:
+    topic = st.selectbox("topic", ["(all)"] + topics)
+
+limit = st.slider("limit", min_value=10, max_value=500, value=100, step=10)
+
+rows = storage.filter_attributions(
+    query=query or None,
+    position=None if position == "(all)" else position,
+    topic=None if topic == "(all)" else topic,
+    limit=limit,
+)
+
+st.write(f"showing {len(rows)} finding(s)")
+if not rows:
+    st.info("No attributions match the current filters.")
+    st.stop()
+
+# Compact table view. Percentage formatted; source kept as a link column.
+table = [
+    {
+        "%": (f"{float(r['percentage']):.0f}" if r.get("percentage") is not None else "—"),
+        "position": r.get("position"),
+        "question": r.get("question"),
+        "population": r.get("population") or "",
+        "confidence": (f"{float(r['confidence']):.2f}" if r.get("confidence") is not None else ""),
+        "source": r.get("source_id"),
+        "study": r.get("title"),
+        "url": r.get("canonical_url"),
+    }
+    for r in rows
+]
+st.dataframe(
+    table,
+    use_container_width=True,
+    hide_index=True,
+    column_config={"url": st.column_config.LinkColumn("url")},
+)
+
+st.caption(
+    "Tip: the same finding can appear across multiple studies. "
+    "Cross-study dedup (confidence-weighted) is a separate read-time view."
+)

--- a/study_scraper/console/pages/5_Sources.py
+++ b/study_scraper/console/pages/5_Sources.py
@@ -1,0 +1,107 @@
+"""Sources — per-source coverage & health (Phase 5d dock surface).
+
+One row per source (catalog: ssoar/openalex → `studies`; lake:
+dawum/gesis/eurostat → `source_records`) with record count, run count,
+errors, and last successful run. Plus the recent-run table. Reuses
+`build_status()`; one small inline query for per-source last-success.
+
+Read-only.
+"""
+
+from __future__ import annotations
+
+import streamlit as st
+
+from study_scraper.console._shared import storage_or_error
+from study_scraper.status import build_status
+
+
+st.set_page_config(page_title="Study scraper — sources", layout="wide")
+st.title("Sources — coverage & health")
+st.caption(
+    "Per-source record counts, run history, and errors. Catalog sources "
+    "write to `studies`; lake sources write to `source_records`."
+)
+
+storage = storage_or_error()
+if storage is None:
+    st.stop()
+
+report = build_status(storage, recent_n=50)
+
+c1, c2, c3, c4 = st.columns(4)
+c1.metric("kept studies", report.kept_count)
+c2.metric("lake records", report.total_source_records)
+c3.metric("clean runs", report.successful_runs)
+c4.metric("runs with errors", report.failed_runs)
+
+st.divider()
+
+# Per-source last-successful run + cumulative errors (inline, like 3_Lake.py).
+with storage.connection() as conn:
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT source_id, "
+            "       MAX(started_at) FILTER (WHERE errors = 0) AS last_ok, "
+            "       MAX(started_at)                           AS last_run, "
+            "       COALESCE(SUM(errors), 0)                  AS total_errors "
+            "FROM   study_scraper.crawl_runs "
+            "GROUP  BY source_id"
+        )
+        run_stats = {r["source_id"]: r for r in cur.fetchall()}
+
+# Known source kinds (catalog vs lake). Unknown sources still show, kind '?'.
+KIND = {
+    "ssoar": "catalog", "openalex": "catalog",
+    "dawum": "lake", "gesis": "lake", "eurostat": "lake",
+}
+
+all_sources = sorted(
+    set(report.studies_per_source)
+    | set(report.source_records_per_source)
+    | set(report.runs_per_source)
+    | set(run_stats)
+)
+
+rows = []
+for sid in all_sources:
+    stats = run_stats.get(sid, {})
+    last_ok = stats.get("last_ok")
+    records = (
+        report.studies_per_source.get(sid, 0)
+        + report.source_records_per_source.get(sid, 0)
+    )
+    rows.append({
+        "source": sid,
+        "kind": KIND.get(sid, "?"),
+        "records": records,
+        "runs": report.runs_per_source.get(sid, 0),
+        "errors": int(stats.get("total_errors") or 0),
+        "last successful run": (
+            last_ok.isoformat(timespec="seconds") if last_ok else "— never"
+        ),
+    })
+
+st.subheader("per source")
+st.dataframe(rows, use_container_width=True, hide_index=True)
+
+st.subheader("recent runs")
+recent = [
+    {
+        "ok": "ERR" if (r.get("errors") or 0) > 0 else "ok",
+        "source": r.get("source_id"),
+        "topic": r.get("topic_id"),
+        "seen": r.get("candidates_seen"),
+        "kept": r.get("candidates_kept"),
+        "errors": r.get("errors"),
+        "started": (
+            r["started_at"].isoformat(timespec="seconds")
+            if r.get("started_at") else ""
+        ),
+    }
+    for r in report.recent_runs
+]
+if recent:
+    st.dataframe(recent, use_container_width=True, hide_index=True)
+else:
+    st.info("No crawl runs yet.")

--- a/study_scraper/storage/postgres.py
+++ b/study_scraper/storage/postgres.py
@@ -736,6 +736,66 @@ class PostgresStorage:
                 cur.execute(f"SELECT COUNT(*) AS c FROM {SCHEMA}.attributions")
                 return int(cur.fetchone()["c"])
 
+    def filter_attributions(
+        self,
+        *,
+        query: Optional[str] = None,
+        position: Optional[str] = None,
+        topic: Optional[str] = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """Browse attribution triples with optional text/position/topic
+        filters (powers the dock Attributions page). Joins study context;
+        excludes rejected studies. Ordered by percentage then confidence."""
+        clauses: List[str] = ["s.status <> 'rejected'"]
+        params: List[Any] = []
+        if query:
+            clauses.append("lower(a.question) LIKE %s")
+            params.append(f"%{query.lower()}%")
+        if position:
+            clauses.append("a.position = %s")
+            params.append(position)
+        if topic:
+            clauses.append("%s = ANY(s.topic_ids)")
+            params.append(topic)
+        where = " AND ".join(clauses)
+        params.append(limit)
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT a.question, a.position, a.percentage, a.population,
+                           a.confidence, a.model,
+                           s.title, s.canonical_url, s.source_id,
+                           s.publication_date, s.topic_ids
+                    FROM   {SCHEMA}.attributions a
+                    JOIN   {SCHEMA}.studies s ON s.id = a.study_id
+                    WHERE  {where}
+                    ORDER  BY a.percentage DESC NULLS LAST,
+                              a.confidence DESC NULLS LAST
+                    LIMIT  %s
+                    """,
+                    params,
+                )
+                return list(cur.fetchall())
+
+    def list_distinct_attribution_topics(self) -> List[str]:
+        """Distinct topic_ids appearing on studies that have attributions —
+        populates the dock's topic filter dropdown."""
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT DISTINCT unnest(s.topic_ids) AS t
+                    FROM   {SCHEMA}.attributions a
+                    JOIN   {SCHEMA}.studies s ON s.id = a.study_id
+                    WHERE  s.status <> 'rejected'
+                      AND  array_length(s.topic_ids, 1) > 0
+                    ORDER  BY t
+                    """
+                )
+                return [r["t"] for r in cur.fetchall()]
+
     def get_study_for_attribution(self, study_id: str) -> Optional[Dict[str, Any]]:
         """Study + its claim snippets, for feeding the llm-v1 extractor."""
         with self.connection() as conn:

--- a/tests/study_scraper/test_console.py
+++ b/tests/study_scraper/test_console.py
@@ -26,6 +26,8 @@ PAGE_FILES = [
     CONSOLE_DIR / "pages" / "1_Topics.py",
     CONSOLE_DIR / "pages" / "2_Review.py",
     CONSOLE_DIR / "pages" / "3_Lake.py",
+    CONSOLE_DIR / "pages" / "4_Attributions.py",
+    CONSOLE_DIR / "pages" / "5_Sources.py",
 ]
 
 


### PR DESCRIPTION
**Build items 5 & 6 — dock pages.**

- `console/pages/4_Attributions.py` — browse/filter the `(question, position, percentage)` triples: free-text search, position + topic filters, sorted by percentage, links to source. The human answer layer.
- `console/pages/5_Sources.py` — per-source coverage & health: catalog vs lake record counts, run counts, errors, last successful run, recent-run table. Reuses `build_status`.
- `storage.filter_attributions` + `list_distinct_attribution_topics` back the attributions page.

Page-compile tests for both; full suite **87 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_