### PR TITLE
Accuracy F4: claims regex catches German percentage words

### DIFF
--- a/study_scraper/claims.py
+++ b/study_scraper/claims.py
@@ -48,13 +48,25 @@ _EN_OPINION_HINTS = (
 _OPINION_HINTS = _DE_OPINION_HINTS + _EN_OPINION_HINTS
 
 
-# A number followed by a percent sign, possibly with a comma/dot decimal,
-# possibly with a space between number and "%". Examples we want to catch:
-#   62%, 62 %, 62,5 %, 62.5%, 6.063 % (rare but ok)
+# A number followed by a percent marker. German polling prose writes the
+# unit many ways, not just "%": "62 Prozent", "55 v.H.", "vom Hundert",
+# and "Prozentpunkte" (percentage points — a *change*, kept as unit 'pp').
+# Examples caught: 62%, 62 %, 62,5 %, 62.5%, 6.063 %, "62 Prozent",
+# "55 v.H.", "3 Prozentpunkte". `\s*` so newlines/double-spaces don't break it.
+# Order matters: longest alternatives first (prozentpunkte before prozent).
 _PERCENT_RE = re.compile(
-    r"(?P<value>\d+(?:[.,]\d+)?)\s?%",
-    re.UNICODE,
+    r"(?P<value>\d+(?:[.,]\d+)?)\s*"
+    r"(?P<unit>%|prozentpunkte|prozentpunkt|prozent|v\.?\s?h\.?|vom\s+hundert)",
+    re.UNICODE | re.IGNORECASE,
 )
+
+
+def _normalize_pct_unit(raw: str) -> str:
+    """Map a matched percent marker to a canonical unit: '%' or 'pp'."""
+    low = raw.lower().replace(" ", "")
+    if low.startswith("prozentpunkt"):
+        return "pp"  # percentage points: a change, not a level
+    return "%"
 
 # "n=1024", "n = 1024", "(n=1009," — sample-size cues, kept as a claim
 # type so the dock can show "based on a sample of X".
@@ -142,13 +154,15 @@ def _extract_from_field(
     out: List[ExtractedClaim],
 ) -> None:
     """Append claims found in one text field to `out` (shared dedup set)."""
-    # Percent matches
+    # Percent matches (incl. German word forms: Prozent / v.H. / vom Hundert)
     for m in _PERCENT_RE.finditer(text):
         value = _value_to_float(m.group("value"))
         if value is None:
             continue
-        # Optional sanity: a percent of >120 is almost always not a
-        # poll figure; suppress those.
+        unit = _normalize_pct_unit(m.group("unit"))
+        # Optional sanity: a percent *level* >120 is almost never a poll
+        # figure; suppress those. Percentage-point *changes* ('pp') are
+        # genuinely small, so the same ceiling is fine.
         if value > 120.0:
             continue
         snippet = _trim_snippet(text, m.start(), m.end())
@@ -163,7 +177,7 @@ def _extract_from_field(
                 study_id=study_id,
                 claim_text=snippet,
                 numeric_value=value,
-                unit="%",
+                unit=unit,
                 source_field=source_field,
             )
         )

--- a/tests/study_scraper/test_claims_german_pct.py
+++ b/tests/study_scraper/test_claims_german_pct.py
@@ -1,0 +1,66 @@
+"""Accuracy fix F4: claims regex must catch German word-form percentages,
+not just the '%' sign. Pure-function tests (no DB)."""
+
+from __future__ import annotations
+
+from study_scraper.claims import _normalize_pct_unit, extract_claims_from_text
+
+
+def _values(text: str, unit: str | None = None):
+    claims = extract_claims_from_text(study_id="s", text=text)
+    return [c.numeric_value for c in claims if unit is None or c.unit == unit]
+
+
+def test_prozent_word_is_captured() -> None:
+    vals = _values("62 Prozent der Befragten befürworten das Gesetz.", unit="%")
+    assert 62.0 in vals
+
+
+def test_prozent_no_space() -> None:
+    vals = _values("Zustimmung lag bei 47Prozent.", unit="%")
+    assert 47.0 in vals
+
+
+def test_v_h_abbreviation() -> None:
+    vals = _values("55 v.H. der Wähler lehnen dies ab.", unit="%")
+    assert 55.0 in vals
+
+
+def test_vom_hundert() -> None:
+    vals = _values("Rund 30 vom Hundert sind unentschieden.", unit="%")
+    assert 30.0 in vals
+
+
+def test_percent_sign_still_works() -> None:
+    vals = _values("62% Zustimmung, 36 % Ablehnung.", unit="%")
+    assert 62.0 in vals and 36.0 in vals
+
+
+def test_prozentpunkte_tagged_pp_not_percent() -> None:
+    claims = extract_claims_from_text(
+        study_id="s", text="Die Union verliert 3 Prozentpunkte gegenüber Vormonat."
+    )
+    pp = [c for c in claims if c.unit == "pp"]
+    assert any(c.numeric_value == 3.0 for c in pp)
+    # ...and it is NOT mislabeled as a level percentage
+    assert not any(c.numeric_value == 3.0 and c.unit == "%" for c in claims)
+
+
+def test_decimal_comma_with_prozent() -> None:
+    vals = _values("62,5 Prozent Zustimmung.", unit="%")
+    assert 62.5 in vals
+
+
+def test_normalize_unit_helper() -> None:
+    assert _normalize_pct_unit("%") == "%"
+    assert _normalize_pct_unit("Prozent") == "%"
+    assert _normalize_pct_unit("v.H.") == "%"
+    assert _normalize_pct_unit("vom Hundert") == "%"
+    assert _normalize_pct_unit("Prozentpunkte") == "pp"
+    assert _normalize_pct_unit("Prozentpunkt") == "pp"
+
+
+def test_over_120_suppressed() -> None:
+    # methodology/year-ish big numbers with a unit are still suppressed
+    vals = _values("Die Zahl stieg um 250 Prozent.", unit="%")
+    assert 250.0 not in vals


### PR DESCRIPTION
**Accuracy fix F4** (from the data-flow audit) — claims recall on German prose.

The regex claim extractor matched only the `%` sign, silently missing common German polling forms. Now also catches:
- `62 Prozent`, `47Prozent` (no space)
- `55 v.H.`, `30 vom Hundert`
- `3 Prozentpunkte` → tagged unit `pp` (percentage-point *change*, kept distinct from a level `%`)

Whitespace widened `\s?`→`\s*` so line breaks/double spaces don't break matches.

Why it matters: the LLM attribution can only label numbers the regex surfaces, so this lifts the recall ceiling for the whole downstream pipeline on real German text.

9 pure tests; full suite **96 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_