### PR TITLE
Auto-reviewer: zero-touch triage of the pending queue

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -68,6 +68,15 @@ jobs:
               --code env_air_gge --code nrg_bal_s --code demo_pjan
           exit 0
 
+      - name: Auto-review the pending queue (zero-touch)
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          POSTGRES_URL: ${{ secrets.SCRAPER_POSTGRES_URL }}
+        run: |
+          # Resolve borderline 'pending' studies to kept/rejected so they
+          # flow on to full-text + attribution without waiting on a human.
+          python -m study_scraper review auto --limit 1000 || true
+
       - name: Follow citation graph (one hop)
         if: steps.gate.outputs.enabled == 'true'
         env:

--- a/study_scraper/auto_review.py
+++ b/study_scraper/auto_review.py
@@ -1,0 +1,113 @@
+"""Auto-reviewer for borderline 'pending' studies (zero-touch loop).
+
+The pipeline parks studies with 0 < topic-score < 0.2 as `status='pending'`
+for optional human review (Q12). The maintainer wants a fully automated
+loop — nothing should wait on a person. This module triages the pending
+band automatically, coverage-first (A12: bias to keep), so every study
+ends up `kept` or `rejected` and flows on to claims/attribution.
+
+Design:
+  - `decide(...)` is pure and offline-testable — the whole policy lives
+    here. It NEVER returns "skip": the point is zero pending left.
+  - `run_auto_review(...)` applies decisions via the existing
+    promote_study / reject_study storage methods (which stamp
+    `reviewed_by='auto'`), and records the rationale in provenance for
+    audit. `dry_run=True` previews without writing.
+
+Rule-based and free (no LLM, no network) — runs anywhere, including the
+scheduled attribute Action. An LLM second opinion can be layered later.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+from study_scraper.storage import PostgresStorage
+
+
+LOGGER = logging.getLogger(__name__)
+
+AUTO_REVIEWER = "auto"
+
+# A study needs at least this much text to be considered more than a stub.
+_MIN_TEXT = 40
+# Below this score AND with no other signal, treat as noise.
+_NOISE_SCORE = 0.05
+# At/above this score, keep outright (close to the 0.2 keep threshold).
+_NEAR_THRESHOLD = 0.1
+
+
+def decide(
+    *,
+    title: Optional[str],
+    abstract: Optional[str],
+    claims_count: int,
+    max_score: Optional[float],
+) -> Tuple[str, str]:
+    """Return (decision, rationale) for one pending study.
+
+    decision is 'kept' or 'rejected' — never 'pending'. Coverage-first:
+    keep unless the study is clearly noise.
+    """
+    text_len = len((title or "") + (abstract or ""))
+    score = max_score or 0.0
+
+    if claims_count > 0:
+        return "kept", f"has {claims_count} quantitative claim(s)"
+    if score >= _NEAR_THRESHOLD:
+        return "kept", f"topic score {score:.2f} near keep threshold"
+    if text_len < _MIN_TEXT and score < _NOISE_SCORE:
+        return "rejected", (
+            f"noise: score {score:.2f} and only {text_len} chars of text"
+        )
+    # Coverage-first default: a borderline study with real text and no
+    # disqualifier is kept rather than dropped.
+    return "kept", "coverage-first default (borderline, no disqualifier)"
+
+
+def _max_score(topic_scores: Any) -> Optional[float]:
+    if isinstance(topic_scores, dict) and topic_scores:
+        try:
+            return max(float(v) for v in topic_scores.values())
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+def run_auto_review(
+    *,
+    storage: PostgresStorage,
+    limit: int = 100,
+    topic: Optional[str] = None,
+    dry_run: bool = False,
+) -> List[Dict[str, Any]]:
+    """Triage pending studies. Returns one result dict per study."""
+    rows = storage.list_studies(topic_id=topic, status="pending", limit=limit)
+    results: List[Dict[str, Any]] = []
+    for row in rows:
+        sid = row["id"]
+        claims_count = len(storage.claims_for_study(sid))
+        decision, rationale = decide(
+            title=row.get("title"),
+            abstract=row.get("abstract"),
+            claims_count=claims_count,
+            max_score=_max_score(row.get("topic_scores")),
+        )
+        if not dry_run:
+            storage.set_review_rationale(sid, f"auto: {rationale}")
+            if decision == "kept":
+                storage.promote_study(sid, reviewed_by=AUTO_REVIEWER)
+            else:
+                storage.reject_study(
+                    sid, reviewed_by=AUTO_REVIEWER, reason=rationale
+                )
+        results.append({
+            "study_id": sid,
+            "decision": decision,
+            "rationale": rationale,
+            "title": (row.get("title") or "")[:80],
+            "applied": not dry_run,
+        })
+        LOGGER.info("auto-review %s -> %s (%s)", sid[:12], decision, rationale)
+    return results

--- a/study_scraper/cli.py
+++ b/study_scraper/cli.py
@@ -646,5 +646,30 @@ def review_reject(
     typer.echo("rejected" if changed else "no change (already rejected or unknown id)")
 
 
+@review_app.command("auto")
+def review_auto(
+    topic: Optional[str] = typer.Option(None, "--topic"),
+    limit: int = typer.Option(100, "--limit"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview, don't write."),
+) -> None:
+    """Auto-triage the pending queue (zero-touch loop): promote/reject every
+    pending study, coverage-first. Stamps reviewed_by='auto' + a rationale."""
+    from study_scraper.auto_review import run_auto_review
+
+    storage = _storage_from_settings()
+    results = run_auto_review(
+        storage=storage, limit=limit, topic=topic, dry_run=dry_run,
+    )
+    if not results:
+        typer.echo("(nothing pending)")
+        return
+    kept = sum(1 for r in results if r["decision"] == "kept")
+    rejected = sum(1 for r in results if r["decision"] == "rejected")
+    prefix = "[dry-run] " if dry_run else ""
+    for r in results:
+        typer.echo(f"{prefix}{r['study_id'][:12]}  {r['decision']:<8}  {r['rationale']}")
+    typer.echo(f"{prefix}auto-review: {kept} kept, {rejected} rejected")
+
+
 if __name__ == "__main__":
     app()

--- a/study_scraper/storage/postgres.py
+++ b/study_scraper/storage/postgres.py
@@ -498,6 +498,23 @@ class PostgresStorage:
             conn.commit()
         return changed
 
+    def set_review_rationale(self, study_id: str, rationale: str) -> bool:
+        """Record why a study was auto-reviewed, merged into provenance jsonb
+        (audit trail for the auto-reviewer; no schema change). True if updated."""
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"UPDATE {SCHEMA}.studies "
+                    f"   SET provenance = COALESCE(provenance, '{{}}'::jsonb) "
+                    f"       || jsonb_build_object('review_rationale', %s::text), "
+                    f"       updated_at = now() "
+                    f" WHERE id = %s",
+                    (rationale, study_id),
+                )
+                changed = cur.rowcount > 0
+            conn.commit()
+        return changed
+
     def set_resolved_pdf_url(self, study_id: str, pdf_url: str) -> bool:
         """Record the PDF URL resolved from a landing page, merged into the
         study's provenance jsonb (no schema change). Keeps the audit trail:

--- a/tests/study_scraper/test_auto_review.py
+++ b/tests/study_scraper/test_auto_review.py
@@ -1,0 +1,56 @@
+"""Tests for the auto-reviewer policy (pure; no DB). Coverage-first: the
+pending band is always resolved to kept/rejected, biased to keep."""
+
+from __future__ import annotations
+
+from study_scraper.auto_review import decide, _max_score
+
+
+GOOD_ABSTRACT = "Eine repräsentative Umfrage unter 1000 Befragten zum Klimaschutz."
+
+
+def test_claims_present_is_kept() -> None:
+    decision, why = decide(
+        title="Klima", abstract=GOOD_ABSTRACT, claims_count=3, max_score=0.05,
+    )
+    assert decision == "kept"
+    assert "claim" in why
+
+
+def test_near_threshold_score_is_kept() -> None:
+    decision, _ = decide(
+        title="Klima", abstract=GOOD_ABSTRACT, claims_count=0, max_score=0.15,
+    )
+    assert decision == "kept"
+
+
+def test_borderline_with_text_defaults_to_kept() -> None:
+    # coverage-first: real text, low score, no claims -> still keep
+    decision, why = decide(
+        title="Eine Studie", abstract=GOOD_ABSTRACT, claims_count=0, max_score=0.07,
+    )
+    assert decision == "kept"
+    assert "coverage-first" in why
+
+
+def test_noise_is_rejected() -> None:
+    # almost no text and a near-zero score -> noise
+    decision, why = decide(
+        title="x", abstract="", claims_count=0, max_score=0.02,
+    )
+    assert decision == "rejected"
+    assert "noise" in why
+
+
+def test_never_returns_pending() -> None:
+    # whatever the inputs, the band is always resolved
+    for cc, sc, ab in [(0, 0.0, ""), (0, 0.19, GOOD_ABSTRACT), (5, 0.0, "x")]:
+        decision, _ = decide(title="t", abstract=ab, claims_count=cc, max_score=sc)
+        assert decision in ("kept", "rejected")
+
+
+def test_max_score_helper() -> None:
+    assert _max_score({"klima": 0.1, "steuern": 0.3}) == 0.3
+    assert _max_score({}) is None
+    assert _max_score(None) is None
+    assert _max_score("nonsense") is None


### PR DESCRIPTION
**Auto-reviewer — the zero-touch loop** (the manual-review gap you flagged).

The pipeline parks `0 < score < 0.2` studies as `pending`, and attribution only pulls `kept` — so pending studies waited on a human. This resolves the whole band automatically, **coverage-first**:

- `study_scraper/auto_review.py` — pure `decide()` policy: keep if it has claims / a near-threshold score / real text; reject only clear noise; **never leaves anything pending**. `run_auto_review()` applies via the existing `promote_study`/`reject_study` (stamped `reviewed_by="auto"`) and records the rationale in provenance.
- `storage.set_review_rationale` (provenance jsonb; no migration).
- CLI: `study_scraper review auto [--topic --limit --dry-run]`.
- **Wired into `scrape.yml`**: runs after each crawl, before full-text — so newly-promoted studies get their whole document read the same run.

Net: nothing waits on you; the borderline band flows straight through to claims → attribution.

6 pure policy tests; full suite **126 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_