### PR TITLE
Cross-study finding dedup (confidence-weighted, read-time)

### DIFF
--- a/study_scraper/cli.py
+++ b/study_scraper/cli.py
@@ -359,13 +359,22 @@ def ask(
         ..., help="Keyword(s) to look for inside attribution questions."
     ),
     limit: int = typer.Option(20, "--limit"),
+    dedup: bool = typer.Option(
+        True, "--dedup/--no-dedup",
+        help="Collapse the same finding across studies to one "
+             "confidence-weighted representative (default on).",
+    ),
 ) -> None:
     """Query structured attributions (question, position, %) — the
     llm-v1 answer layer (A21). Richer than `search`: each hit names the
-    question, the stance, and the figure.
+    question, the stance, and the figure. By default duplicates of the
+    same finding are merged; pass --no-dedup to see every raw row.
     """
     storage = _storage_from_settings()
-    rows = storage.search_attributions(query=query, limit=limit)
+    rows = (
+        storage.search_attributions_deduped(query=query, limit=limit)
+        if dedup else storage.search_attributions(query=query, limit=limit)
+    )
     if not rows:
         typer.echo("(no attributions matched — run `attribute` first?)")
         return
@@ -374,6 +383,9 @@ def ask(
         pct_str = f"{float(pct):>5.1f}%" if pct is not None else "   — "
         pos = (row.get("position") or "").ljust(11)
         q = (row.get("question") or "").replace("\n", " ")
+        dup = row.get("dup_count") or 1
+        if dup > 1:
+            q = f"{q}  (+{dup - 1} more)"
         typer.echo(f"{pct_str}  {pos}  {q}")
         title = (row.get("title") or "").replace("\n", " ")
         if len(title) > 70:

--- a/study_scraper/findings.py
+++ b/study_scraper/findings.py
@@ -1,0 +1,102 @@
+"""Cross-study dedup of survey findings (confidence-weighted, read-time).
+
+The same finding ("62% support a climate law") can appear across several
+studies/attributions — the same poll cited twice, or two write-ups of one
+survey. For the answer layer we want ONE representative per distinct
+finding, not N near-duplicates.
+
+This is done at READ time over the rows `search_attributions` returns:
+raw attribution rows stay untouched (full audit trail), dedup is a pure
+function applied before display. No migration, fully offline-testable.
+
+A finding's identity = (normalized question, position, percentage rounded
+to the nearest whole point). Within a group we keep the highest-confidence
+row (ties broken by higher percentage, then by presence of a grounded
+source span), and report how many duplicates it stood for.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+
+def _norm_question(q: Optional[str]) -> str:
+    return re.sub(r"\s+", " ", (q or "").lower()).strip()
+
+
+def dedup_finding_key(
+    question: Optional[str],
+    position: Optional[str],
+    percentage: Optional[float],
+) -> Tuple[str, str, Optional[int]]:
+    """Identity of a finding for dedup. Percentage rounds to the nearest
+    whole point so 61.6% and 62% collapse; None stays distinct."""
+    pos = (position or "unspecified").strip().lower()
+    pct: Optional[int]
+    if percentage is None:
+        pct = None
+    else:
+        try:
+            pct = int(round(float(percentage)))
+        except (TypeError, ValueError):
+            pct = None
+    return (_norm_question(question), pos, pct)
+
+
+def _confidence(row: Dict[str, Any]) -> float:
+    c = row.get("confidence")
+    try:
+        return float(c) if c is not None else 0.0
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _percentage(row: Dict[str, Any]) -> float:
+    p = row.get("percentage")
+    try:
+        return float(p) if p is not None else -1.0
+    except (TypeError, ValueError):
+        return -1.0
+
+
+def _grounded(row: Dict[str, Any]) -> int:
+    raw = row.get("raw")
+    if isinstance(raw, dict) and raw.get("grounded") is True:
+        return 1
+    return 0
+
+
+def dedupe_attributions(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Collapse rows to one representative per finding key.
+
+    Representative = max by (confidence, grounded, percentage). Each kept
+    row gains `dup_count` (how many rows shared its key, incl. itself).
+    Input order of distinct findings is preserved (first appearance wins
+    the slot), so an already-sorted list stays sorted.
+    """
+    best: Dict[Tuple[str, str, Optional[int]], Dict[str, Any]] = {}
+    counts: Dict[Tuple[str, str, Optional[int]], int] = {}
+    order: List[Tuple[str, str, Optional[int]]] = []
+
+    for row in rows:
+        key = dedup_finding_key(
+            row.get("question"), row.get("position"), row.get("percentage")
+        )
+        counts[key] = counts.get(key, 0) + 1
+        if key not in best:
+            best[key] = row
+            order.append(key)
+            continue
+        cur = best[key]
+        challenger = (_confidence(row), _grounded(row), _percentage(row))
+        incumbent = (_confidence(cur), _grounded(cur), _percentage(cur))
+        if challenger > incumbent:
+            best[key] = row
+
+    out: List[Dict[str, Any]] = []
+    for key in order:
+        rep = dict(best[key])
+        rep["dup_count"] = counts[key]
+        out.append(rep)
+    return out

--- a/study_scraper/storage/postgres.py
+++ b/study_scraper/storage/postgres.py
@@ -732,7 +732,7 @@ class PostgresStorage:
                 cur.execute(
                     f"""
                     SELECT a.question, a.position, a.percentage, a.population,
-                           a.confidence, a.model,
+                           a.confidence, a.model, a.raw,
                            s.title, s.canonical_url, s.source_id,
                            s.publication_date
                     FROM   {SCHEMA}.attributions a
@@ -746,6 +746,18 @@ class PostgresStorage:
                     (f"%{query.lower()}%", limit),
                 )
                 return list(cur.fetchall())
+
+    def search_attributions_deduped(
+        self, *, query: str, limit: int = 50
+    ) -> List[Dict[str, Any]]:
+        """Like `search_attributions` but collapses the same finding seen
+        across multiple studies to one confidence-weighted representative
+        (carries `dup_count`). Dedup is read-time in Python; raw rows are
+        untouched. Fetches a wider window first so dedup has material."""
+        from study_scraper.findings import dedupe_attributions
+
+        raw_rows = self.search_attributions(query=query, limit=max(limit * 5, 200))
+        return dedupe_attributions(raw_rows)[:limit]
 
     def count_attributions(self) -> int:
         with self.connection() as conn:

--- a/tests/study_scraper/test_findings_dedup.py
+++ b/tests/study_scraper/test_findings_dedup.py
@@ -1,0 +1,76 @@
+"""Tests for cross-study finding dedup (pure; no DB)."""
+
+from __future__ import annotations
+
+from study_scraper.findings import dedup_finding_key, dedupe_attributions
+
+
+def _row(q, pos, pct, conf, grounded=None, title="t"):
+    return {
+        "question": q, "position": pos, "percentage": pct,
+        "confidence": conf, "title": title,
+        "raw": {"grounded": grounded} if grounded is not None else {},
+    }
+
+
+def test_key_rounds_percentage_to_whole_point() -> None:
+    assert dedup_finding_key("Q", "support", 61.6) == dedup_finding_key("Q", "support", 62.0)
+    assert dedup_finding_key("Q", "support", 62) == ("q", "support", 62)
+
+
+def test_key_normalizes_question_whitespace_case() -> None:
+    a = dedup_finding_key("  Climate  Law ", "support", 50)
+    b = dedup_finding_key("climate law", "support", 50)
+    assert a == b
+
+
+def test_key_none_percentage_distinct_from_value() -> None:
+    assert dedup_finding_key("Q", "support", None)[2] is None
+    assert dedup_finding_key("Q", "support", None) != dedup_finding_key("Q", "support", 50)
+
+
+def test_dedupe_keeps_highest_confidence() -> None:
+    rows = [
+        _row("Climate law", "support", 62, 0.6),
+        _row("climate law", "support", 62.0, 0.9),   # dup, higher conf
+        _row("Climate law", "support", 61.7, 0.5),   # dup (rounds to 62)
+    ]
+    out = dedupe_attributions(rows)
+    assert len(out) == 1
+    assert out[0]["confidence"] == 0.9
+    assert out[0]["dup_count"] == 3
+
+
+def test_dedupe_distinct_positions_kept_separate() -> None:
+    rows = [
+        _row("Tempolimit", "support", 60, 0.8),
+        _row("Tempolimit", "oppose", 30, 0.8),
+    ]
+    out = dedupe_attributions(rows)
+    assert len(out) == 2
+
+
+def test_dedupe_preserves_first_appearance_order() -> None:
+    rows = [
+        _row("B question", "support", 50, 0.5),
+        _row("A question", "support", 70, 0.5),
+        _row("b question", "support", 50.2, 0.9),  # dup of first
+    ]
+    out = dedupe_attributions(rows)
+    assert [r["question"] for r in out] == ["b question", "A question"]
+    # first slot kept, but representative is the higher-confidence dup
+    assert out[0]["confidence"] == 0.9
+
+
+def test_dedupe_grounded_breaks_confidence_tie() -> None:
+    rows = [
+        _row("Q", "support", 50, 0.8, grounded=False),
+        _row("Q", "support", 50, 0.8, grounded=True),  # same conf, grounded wins
+    ]
+    out = dedupe_attributions(rows)
+    assert len(out) == 1
+    assert out[0]["raw"]["grounded"] is True
+
+
+def test_empty_input() -> None:
+    assert dedupe_attributions([]) == []


### PR DESCRIPTION
**Cross-study finding dedup** (answer quality) — the same finding cited across multiple studies should show once.

- `study_scraper/findings.py` — pure `dedup_finding_key` (normalized question + position + percentage rounded to a whole point) and `dedupe_attributions` (keep the max by confidence → grounded → percentage; carries `dup_count`; preserves first-appearance order so a sorted list stays sorted).
- `storage.search_attributions_deduped` — fetches a wider window, dedupes in Python, returns top N. **Raw rows untouched** (full audit trail). Added `a.raw` to `search_attributions` for the grounded tiebreak.
- CLI `ask --dedup/--no-dedup` (default on); merged hits show `(+N more)`.

Read-time only — **no migration**. 8 pure tests; full suite **134 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_