### PR TITLE
docs: ACCURACY.md + TODO status for the build pass

### DIFF
--- a/docs/study_scraper/ACCURACY.md
+++ b/docs/study_scraper/ACCURACY.md
@@ -1,0 +1,70 @@
+# ACCURACY — data-flow audit & fixes
+
+The pipeline is a funnel; errors compound left to right:
+
+```
+topic scoring → regex claims → PDF/full-text → LLM attribution → dedup → answer
+```
+
+A stage-by-stage audit (2026-06-26) ranked the accuracy risks and the
+sandbox-buildable fixes. This file records what was done and what remains.
+
+## Shipped accuracy fixes
+
+| Fix | Stage | What | PR |
+|---|---|---|---|
+| **F1** | LLM | `source_span` required in output + verified as a verbatim substring of the source; ungrounded findings flagged `grounded=False` and confidence capped at 0.3. Threaded through live + offline paths. | #13 |
+| **F3** | LLM | German stance-verb lexicon in the prompt (befürworten/lehnen ab/unentschieden/…); parser maps stray German positions to the enum. | #13 |
+| **F5** | LLM | Per-question distribution sanity: support+oppose+neutral >120% → `raw.distribution_check=false` (audit-only). | #13 |
+| **F4** | claims | Regex catches German `Prozent` / `v.H.` / `vom Hundert` / `Prozentpunkte`, not just `%`. | #12 |
+| **F6** | topic | German morphology: inflected/stem keywords added for the 4 topics (Zuwanderer, Emission, Studierende, Gewerbesteuer, …); excludes still short-circuit. | #14 |
+| PDF | extract | Landing-page → PDF resolver, so full-text reads the actual document (SSOAR handles etc.) not the landing page. | #10 |
+| dedup | answer | Cross-study finding dedup (confidence-weighted, read-time). | #16 |
+
+**Traceability**: every finding now carries `source_span` (the verbatim
+German sentence) and `grounded` (checked True/False). `provenance` carries
+`resolved_pdf_url` (which document was read) and `review_rationale` (why a
+study was auto-kept/rejected).
+
+## Deferred — buildable, lower marginal value
+
+- **F2 (claim_id FK on attributions).** A structured link from a triple to
+  the exact claim row. Largely covered by F1's `source_span`; revisit if a
+  structured join is needed (would add a migration + prompt field).
+- **Dual-target lake attribution.** DAWUM polls are party vote-intention,
+  which don't fit `(question, position=support/oppose, %)`. Forcing it
+  would reduce accuracy; surface DAWUM via its typed views instead. Parser
+  `source_record_id` support already exists for a future policy-opinion
+  lake source.
+- **F7 structured-lake metadata** (German `sample_size` parsing, Eurostat
+  oversized→pending, GESIS DOI validation) — small, do when a real fixture
+  exposes the loss.
+
+## Needs the maintainer (can't be done in-sandbox)
+
+- **Gold set** — the real accuracy number needs ~50 studies (≈12/topic)
+  with hand-extracted `(question, position, percentage, source_span)`
+  triples, plus ~40 on/off-topic titles for the topic-filter recall test.
+  This is the long pole; everything measurable hangs off it.
+- **OCR** for scanned PDFs — needs `tesseract` on the host (system pkg).
+- **spaCy lemmatization** — full fix for German morphology (F6 is the
+  keyword-only partial); needs `pip install spacy` + a model download.
+- **Live-API / Cowork validation** of the F1/F3 prompt changes — the
+  parser changes are tested offline, but real hallucination-rate and
+  confidence-calibration numbers need a run against real studies. Editing
+  `SYSTEM_PROMPT` invalidates the prompt cache, so batch prompt edits.
+
+## Measurement plan (stand up next)
+
+1. **Invariant tests (no labeling, buildable now):** topic recall@0.2 on a
+   small tagged title list; claims capture-rate on German % snippets (the
+   F4 acceptance number); LLM parser invariants — every stored `source_span`
+   grounds, per-question sums ≤120%, stance verbs map. (F4/F6/F1/F5 tests
+   already seed these.)
+2. **Gold-set harness** (`eval/run_eval.py`, offline over captured model
+   outputs): exact-triple accuracy, hallucination rate (span-not-found),
+   false-negative rate, confidence calibration → `docs/study_scraper/eval/accuracy.md`.
+3. **Spot-check CLI** (`audit --sample-size 20`): dumps random stored
+   findings with `source_span` + URL for a weekly manual pass/fail.
+
+Build order once the gold set lands: harness → calibration → tune prompt.

--- a/docs/study_scraper/TODO.md
+++ b/docs/study_scraper/TODO.md
@@ -34,10 +34,13 @@ before they start.
 - [x] 19 tests; 233 total.
 
 ### Attribution follow-ups (sandbox-buildable)
-- [ ] Dual-target attribution on `source_record`s (table already
-      supports it; orchestrator currently studies-only).
-- [ ] Cross-study dedup of the same finding (confidence-weighted).
-- [ ] Dock: an Attributions page (browse / filter triples).
+- [~] Dual-target attribution on `source_record`s — DEFERRED: DAWUM is
+      party vote-intention, doesn't fit (question, position, %); parser
+      `source_record_id` support shipped, awaiting a policy-opinion lake
+      source. See ACCURACY.md.
+- [x] Cross-study dedup of the same finding (confidence-weighted) — PR #16
+      (`findings.py`, `ask --dedup`).
+- [x] Dock: an Attributions page (browse / filter triples) — PR #11.
 
 ### Done in the production pass (2026-06-11, A20)
 - [x] Full-document fetch + extraction (`fulltext.py`, regex-v2).
@@ -48,19 +51,28 @@ before they start.
 - [x] RUNBOOK.md.
 
 ### Next build items (sandbox-buildable, in order of yield)
-5. **Landing-page → PDF resolver** — many canonical_urls are HTML
-   landing pages linking the actual PDF (SSOAR handles especially).
-   Build after the first live `fulltext` run shows the hit rate
-   (RUNBOOK §3 flags this as the expected top gap).
-6. **LLM claim extractor (`llm-v1`)** — disambiguate WHAT each %
-   refers to; turns claims into (question, answer, %) triples — the
-   real shape of an issue-polling system. Schema ready (extractor
-   column); needs API-key + cost decision from maintainer.
-7. **Destatis GENESIS lake source** (free registration needed).
-8. **UBA / BAMF structured downloads** (XLSX/CSV lake sources).
-9. **Per-table SQL views** as access patterns surface.
-10. **Dock: Sources page** — per-source coverage, last-run, errors.
-11. **Eval harness (Phase 7)** — needs maintainer-curated gold set.
+5. [x] **Landing-page → PDF resolver** — PR #10 (`pdf_resolver.py`,
+   wired into `fulltext.py`; resolved URL in provenance).
+6. [x] **LLM claim/attribution extractor (`llm-v1`)** — shipped A21;
+   accuracy hardened (source-span grounding, German stance lexicon) in
+   PR #13. See ACCURACY.md.
+7. [ ] **Destatis GENESIS lake source** (free registration needed) — NOT
+   sandbox-buildable (credentials).
+8. [ ] **UBA / BAMF structured downloads** (XLSX/CSV lake sources).
+9. [ ] **Per-table SQL views** as access patterns surface.
+10. [x] **Dock: Sources page** — PR #11.
+11. [ ] **Eval harness (Phase 7)** — needs maintainer-curated gold set
+    (see ACCURACY.md "Needs the maintainer").
+
+### Accuracy pass (2026-06-26 audit; see ACCURACY.md)
+- [x] F1 source-span grounding + F3 German stance lexicon + F5
+      distribution sanity (PR #13).
+- [x] F4 German percentage words in claims regex (PR #12).
+- [x] F6 German morphology in topic keywords (PR #14).
+- [x] Auto-reviewer: zero-touch pending triage (PR #15), wired into scrape.yml.
+- [~] F2 claim_id lineage — deferred (covered by F1 source_span).
+- [ ] F7 structured-lake metadata parsing; OCR; spaCy lemmatization;
+      eval gold set — maintainer-gated or lower priority.
 
 ### Deferred / awaiting maintainer call
 12. **Think-tank SitemapSource + polling-firm press releases** (A13


### PR DESCRIPTION
Records the 2026-06-26 data-flow accuracy audit and this build pass.

- `docs/study_scraper/ACCURACY.md` — the funnel, the shipped fixes (F1/F3/F4/F5/F6 + PDF resolver + dedup + auto-reviewer) with PR links and the traceability now stored per finding, what's deferred and why (F2, dual-target lake), what needs the maintainer (gold set, OCR, spaCy, live-API validation), and the measurement plan to stand up next.
- `TODO.md` — next-build + attribution-followup checkboxes updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_