### PR TITLE
Self-healing: agent no-op detection + auto-filed needs-human issue

### DIFF
--- a/.github/scripts/check_agent_result.py
+++ b/.github/scripts/check_agent_result.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Parse the claude-code-action execution output and exit non-zero if the
+agent didn't actually do work.
+
+The action writes ${RUNNER_TEMP}/claude-execution-output.json (the SDK
+message stream) but the step exits 0 even when the model call failed
+(e.g. an expired CLAUDE_CODE_OAUTH_TOKEN dies in ~2s with is_error=true,
+num_turns=1, $0 cost). Workflows then look green while the agent team is
+silently dead. This script turns that into a loud failure.
+
+Exit codes: 0 = agent ran fine · 2 = agent errored / no-oped.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def main(path: str) -> int:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except Exception as exc:  # noqa: BLE001 - any parse failure is a fail
+        print(f"::error::cannot parse execution output {path}: {exc}")
+        return 2
+
+    msgs = data if isinstance(data, list) else [data]
+    result = next(
+        (m for m in msgs if isinstance(m, dict) and m.get("type") == "result"),
+        None,
+    )
+    if result is None:
+        print("::error::no result message in Claude execution output")
+        return 2
+
+    if result.get("is_error"):
+        print(
+            "::error::Claude agent result is_error=true "
+            f"(turns={result.get('num_turns')}, "
+            f"duration_ms={result.get('duration_ms')}) — "
+            "likely an expired/invalid CLAUDE_CODE_OAUTH_TOKEN"
+        )
+        return 2
+
+    print(
+        "agent ok: "
+        f"turns={result.get('num_turns')} "
+        f"duration_ms={result.get('duration_ms')} "
+        f"cost_usd={result.get('total_cost_usd')}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: check_agent_result.py <execution-output.json>")
+        raise SystemExit(2)
+    raise SystemExit(main(sys.argv[1]))

--- a/.github/scripts/check_agent_result.sh
+++ b/.github/scripts/check_agent_result.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Self-healing check for Claude agent steps (see check_agent_result.py).
+#
+# If the agent no-oped (missing output, or result.is_error=true — the
+# signature of an expired CLAUDE_CODE_OAUTH_TOKEN), this:
+#   1. files or updates ONE deduped `needs-human` ops issue telling the
+#      maintainer exactly how to fix it, and
+#   2. fails the job, so the run shows RED instead of a silent green.
+#
+# Requires: GH_TOKEN env (pass ${{ github.token }}), runs from repo root.
+
+set -uo pipefail
+
+OUT="${RUNNER_TEMP:-/tmp}/claude-execution-output.json"
+TITLE="[ops] Claude agent runs failing — rotate CLAUDE_CODE_OAUTH_TOKEN"
+
+reason=""
+if [ ! -f "$OUT" ]; then
+  reason="No Claude execution output file was produced."
+elif ! python3 .github/scripts/check_agent_result.py "$OUT"; then
+  reason="The Claude step errored immediately (is_error=true) — the usual cause is an expired or invalid CLAUDE_CODE_OAUTH_TOKEN secret."
+fi
+
+if [ -z "$reason" ]; then
+  echo "self-healing check passed"
+  exit 0
+fi
+
+echo "::error::agent no-op detected: $reason"
+
+BODY="Workflow **${GITHUB_WORKFLOW:-?}** (run ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-?}) detected that the Claude agent step did no work.
+
+**Reason:** $reason
+
+**Fix (2 min):**
+1. On your computer run \`claude setup-token\` and copy the token.
+2. Repo → Settings → Secrets and variables → Actions → update \`CLAUDE_CODE_OAUTH_TOKEN\`.
+3. Re-run any agent workflow — this issue can be closed once a run passes.
+
+Until fixed, ALL Claude-powered workflows (agent-product / monitor / develop / review and scheduled-attribute) are silently no-oping. See docs/study_scraper/AUTONOMY.md failure modes."
+
+if command -v gh >/dev/null 2>&1 && [ -n "${GH_TOKEN:-}" ]; then
+  gh label create needs-human --color d93f0b \
+    --description "Requires a human decision" -R "$GITHUB_REPOSITORY" 2>/dev/null || true
+  existing=$(gh issue list -R "$GITHUB_REPOSITORY" --state open \
+    --search "$TITLE in:title" --json number --jq '.[0].number' 2>/dev/null || true)
+  if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+    gh issue comment "$existing" -R "$GITHUB_REPOSITORY" --body "$BODY" || true
+    echo "updated existing ops issue #$existing"
+  else
+    gh issue create -R "$GITHUB_REPOSITORY" --title "$TITLE" \
+      --body "$BODY" --label needs-human \
+      || gh issue create -R "$GITHUB_REPOSITORY" --title "$TITLE" --body "$BODY" \
+      || true
+    echo "filed new ops issue"
+  fi
+else
+  echo "gh CLI or GH_TOKEN unavailable; skipping issue filing"
+fi
+
+exit 1

--- a/.github/workflows/agent-develop.yml
+++ b/.github/workflows/agent-develop.yml
@@ -57,3 +57,9 @@ jobs:
             tests; run `python -m pytest tests/study_scraper -o addopts="" -q`
             until green. Open ONE PR labeled `agent:review`, body
             "Closes #<n>" when from an issue. DO NOT merge. One task per run.
+
+      - name: Self-healing check — agent must have actually run
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/check_agent_result.sh

--- a/.github/workflows/agent-monitor.yml
+++ b/.github/workflows/agent-monitor.yml
@@ -52,3 +52,9 @@ jobs:
             `agent:task` (dedupe by a stable title — comment instead of
             duplicating). Do not open issues for healthy runs. Never edit
             code, .github/**, or .claude/**.
+
+      - name: Self-healing check — agent must have actually run
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/check_agent_result.sh

--- a/.github/workflows/agent-product.yml
+++ b/.github/workflows/agent-product.yml
@@ -54,3 +54,9 @@ jobs:
             med/low) for the developer agent, and keep docs/study_scraper/
             ROADMAP.md in sync via a normal PR (do NOT push to main; do NOT
             edit .github/** or .claude/**). Be decisive and concise.
+
+      - name: Self-healing check — agent must have actually run
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/check_agent_result.sh

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -62,3 +62,9 @@ jobs:
             issue closes. Otherwise add `agent:changes-requested` and a
             comment listing exactly what must change. Default to NOT merging
             when uncertain.
+
+      - name: Self-healing check — agent must have actually run
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/check_agent_result.sh

--- a/.github/workflows/attribute.yml
+++ b/.github/workflows/attribute.yml
@@ -29,9 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     # claude-code-action authenticates GitHub via OIDC — needs id-token: write.
+    # issues: write lets the self-healing check file a needs-human issue
+    # when the OAuth token dies (see .github/scripts/check_agent_result.sh).
     permissions:
       contents: read
       id-token: write
+      issues: write
     env:
       POSTGRES_URL: ${{ secrets.SCRAPER_POSTGRES_URL }}
     steps:
@@ -92,6 +95,12 @@ jobs:
               4. python -m study_scraper status  (report the new totals)
             Do not commit anything — the output lives in Postgres. Do not
             invent figures. Keep going until the responses file is applied.
+
+      - name: Self-healing check — agent must have actually run
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash .github/scripts/check_agent_result.sh
 
       - name: Status report (post)
         if: steps.gate.outputs.enabled == 'true'

--- a/docs/study_scraper/AGENTS.md
+++ b/docs/study_scraper/AGENTS.md
@@ -56,6 +56,13 @@ itself.
   `pull_request` workflows (GitHub anti-recursion), so the challenger sweeps
   on a schedule and runs tests itself. Worst case is latency (hours), never
   an unverified merge.
+- **Self-healing credential check.** claude-code-action exits 0 even when
+  the model call fails (an expired `CLAUDE_CODE_OAUTH_TOKEN` dies in ~2s
+  with `is_error=true`), which once left the whole team silently dead for
+  days. Every Claude workflow now runs
+  `.github/scripts/check_agent_result.sh` after the agent step: a no-op
+  turns the run RED and files/updates one deduped `needs-human` issue with
+  the exact fix (rotate the token). Silent failure is impossible by design.
 
 ## Cost
 Four scheduled agents + a review sweep every 4h draw on your Claude

--- a/docs/study_scraper/AUTONOMY.md
+++ b/docs/study_scraper/AUTONOMY.md
@@ -117,6 +117,8 @@ laptop at all — point it at `POSTGRES_URL` as a Streamlit secret.
 | `prepared statement "…" already exists` | using Transaction pooler (6543) | switch to Session pooler (5432) |
 | attribute step "queue empty" | no claims yet, or all attributed | expected — run a crawl first |
 | attribute fails auth | bad/expired OAuth token | re-run `claude setup-token`, update the secret |
+| agent run RED, `needs-human` ops issue filed | OAuth token expired — the self-healing check (`.github/scripts/check_agent_result.sh`) caught a no-op agent | rotate `CLAUDE_CODE_OAUTH_TOKEN`, re-run, close the issue |
+| agent runs green but do nothing (pre-fix history) | claude-code-action exits 0 even when the model call errors | fixed: every Claude workflow now verifies the execution output and fails loudly |
 | cron never fires | workflow only on a feature branch | merge to `main` (default branch) |
 | one source errors | upstream API hiccup | non-fatal by design; next run retries |
 


### PR DESCRIPTION
**Root cause found for the silent agent team.** GitHub-side auth works (OIDC + app token succeed), but the Claude call itself dies in ~2s with `is_error: true, num_turns: 1, $0` — the signature of an **expired `CLAUDE_CODE_OAUTH_TOKEN`** (verified in agent-develop run 28455261695). Worse: `claude-code-action` exits **0** anyway, so every workflow has been green while doing nothing since ~06-25.

Silent failure is the opposite of self-healing, so this PR makes it impossible:

- `.github/scripts/check_agent_result.py` — parses the action's execution output; non-zero on `is_error` / missing / unparseable result.
- `.github/scripts/check_agent_result.sh` — on no-op: files/updates **one deduped `needs-human` ops issue** with the exact fix (rotate token → re-run → close), then **fails the job (RED)**.
- Wired into all five Claude workflows (`agent-product/monitor/develop/review` + `scheduled-attribute`); `attribute.yml` gains `issues: write`.
- `AUTONOMY.md` failure modes + `AGENTS.md` safety rails updated.

Scripts tested locally against fail/ok/garbage/missing outputs. No Python app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_