### PR TITLE
Fix #25: fulltext resolves openalex.org URLs via pdf/landing/DOI or skips cleanly

### DIFF
--- a/study_scraper/discovery/openalex.py
+++ b/study_scraper/discovery/openalex.py
@@ -233,6 +233,10 @@ class OpenAlexSource:
             raw={
                 "openalex_id": openalex_id,
                 "doi": doi or None,
+                # Fetchable document locations — openalex.org work pages
+                # are bot-protected metadata, so fulltext needs these.
+                "landing_page_url": primary_location.get("landing_page_url"),
+                "pdf_url": primary_location.get("pdf_url"),
                 "type": work.get("type"),
                 "topics": topics_raw,
                 "keywords": keywords_raw,

--- a/study_scraper/fulltext.py
+++ b/study_scraper/fulltext.py
@@ -186,6 +186,39 @@ def fetch_url(url: str, *, timeout: float = 60.0) -> Tuple[bytes, Optional[str]]
         return resp.content, resp.headers.get("content-type")
 
 
+# openalex.org work pages are bot-protected METADATA pages, never the
+# document — fetching them 403s (seen live 2026-07-02, 7/91 failures).
+_OPENALEX_HOST_RE = re.compile(r"^https?://(www\.)?openalex\.org/", re.I)
+
+
+def select_fetch_url(
+    *,
+    canonical_url: Optional[str],
+    doi: Optional[str] = None,
+    provenance: Optional[Dict[str, Any]] = None,
+) -> Tuple[Optional[str], str]:
+    """Pick the URL fulltext should actually fetch for a study.
+
+    Returns (url, why). Non-openalex canonical URLs pass through
+    unchanged. For openalex.org URLs we prefer, in order: the work's
+    `pdf_url`, its `landing_page_url` (both captured into provenance at
+    ingest), then the DOI. If nothing fetchable exists, (None,
+    'no_fetchable_url') — callers should mark the study so it leaves
+    the fulltext queue instead of 403-ing forever. Pure; no I/O.
+    """
+    if not canonical_url or not _OPENALEX_HOST_RE.match(canonical_url):
+        return canonical_url, "canonical"
+    prov = provenance or {}
+    for key in ("pdf_url", "landing_page_url"):
+        alt = prov.get(key)
+        if isinstance(alt, str) and alt and not _OPENALEX_HOST_RE.match(alt):
+            return alt, key
+    if doi:
+        url = doi if doi.startswith("http") else f"https://doi.org/{doi}"
+        return url, "doi"
+    return None, "no_fetchable_url"
+
+
 def run_fulltext(
     *,
     storage: PostgresStorage,
@@ -210,7 +243,22 @@ def run_fulltext(
     results: List[Dict[str, Any]] = []
     for row in rows:
         sid = row["id"]
-        url = row["canonical_url"]
+        url, why = select_fetch_url(
+            canonical_url=row.get("canonical_url"),
+            doi=row.get("doi"),
+            provenance=row.get("provenance") or {},
+        )
+        if url is None:
+            # Nothing fetchable (openalex-only work, no DOI/location):
+            # flag it so it leaves the queue instead of erroring forever.
+            storage.mark_unfetchable(sid)
+            results.append({
+                "study_id": sid, "status": "no_fetchable_url", "claims": 0,
+                "canonical_url": row.get("canonical_url"),
+                "resolved_pdf_url": None,
+            })
+            LOGGER.info("fulltext %s: no_fetchable_url", sid[:12])
+            continue
         resolved_pdf: Optional[str] = None
         try:
             content, content_type = fetch_url(url)
@@ -241,7 +289,10 @@ def run_fulltext(
                 "claims": 0,
             }
             LOGGER.warning("fulltext fetch failed for %s: %s", url, exc)
-        summary["canonical_url"] = url
+        summary["canonical_url"] = row.get("canonical_url")
+        # Where we actually fetched from, when it wasn't the canonical URL
+        # (openalex fallback via pdf_url / landing_page_url / DOI).
+        summary["fetch_url"] = url if why != "canonical" else None
         summary["resolved_pdf_url"] = resolved_pdf
         results.append(summary)
         LOGGER.info(

--- a/study_scraper/pipeline.py
+++ b/study_scraper/pipeline.py
@@ -77,7 +77,10 @@ def _candidate_to_study(
     if cand.raw:
         # own openalex_id included so the reference-follower can match
         # "already ingested" works whose canonical_url is a DOI.
-        for key in ("openalex_id", "referenced_works", "related_works"):
+        # landing_page_url / pdf_url feed the fulltext URL fallback for
+        # openalex-canonical studies (fulltext.select_fetch_url).
+        for key in ("openalex_id", "referenced_works", "related_works",
+                    "landing_page_url", "pdf_url"):
             value = cand.raw.get(key)
             if value:
                 provenance_extras[key] = value

--- a/study_scraper/storage/postgres.py
+++ b/study_scraper/storage/postgres.py
@@ -549,16 +549,39 @@ class PostgresStorage:
             with conn.cursor() as cur:
                 cur.execute(
                     f"""
-                    SELECT id, canonical_url, title, raw_artifact_ref
+                    SELECT id, canonical_url, title, raw_artifact_ref,
+                           doi, provenance
                     FROM   {SCHEMA}.studies
                     WHERE  status = 'kept'
                       {artifact_clause}
+                      AND  NOT COALESCE(
+                               (provenance->>'no_fetchable_url')::boolean,
+                               false)
                     ORDER  BY fetched_at DESC
                     LIMIT  %s
                     """,
                     (limit,),
                 )
                 return list(cur.fetchall())
+
+    def mark_unfetchable(self, study_id: str) -> bool:
+        """Flag a study as having no fetchable document URL (e.g. an
+        openalex-only work with no DOI/location). Merged into provenance
+        jsonb; `list_studies_for_fulltext` then skips it, so the queue
+        can't 403 on the same study forever. True if updated."""
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"UPDATE {SCHEMA}.studies "
+                    f"   SET provenance = COALESCE(provenance, '{{}}'::jsonb) "
+                    f"       || jsonb_build_object('no_fetchable_url', true), "
+                    f"       updated_at = now() "
+                    f" WHERE id = %s",
+                    (study_id,),
+                )
+                changed = cur.rowcount > 0
+            conn.commit()
+        return changed
 
     # ------------------------------------------------------------------
     # Claims (Phase 6-mini)

--- a/tests/study_scraper/test_fulltext_url_selection.py
+++ b/tests/study_scraper/test_fulltext_url_selection.py
@@ -1,0 +1,99 @@
+"""Fix #25: fulltext must not fetch openalex.org work pages (bot-protected
+metadata, guaranteed 403). Pure tests for select_fetch_url + the provenance
+capture that feeds it."""
+
+from __future__ import annotations
+
+from study_scraper.fulltext import select_fetch_url
+
+
+OA = "https://openalex.org/W123"
+
+
+def test_non_openalex_canonical_passes_through() -> None:
+    url, why = select_fetch_url(
+        canonical_url="https://doi.org/10.1515/x", doi="10.1515/x",
+    )
+    assert url == "https://doi.org/10.1515/x"
+    assert why == "canonical"
+
+
+def test_openalex_prefers_pdf_url() -> None:
+    url, why = select_fetch_url(
+        canonical_url=OA,
+        doi="10.1/x",
+        provenance={"pdf_url": "https://host.org/paper.pdf",
+                    "landing_page_url": "https://host.org/page"},
+    )
+    assert url == "https://host.org/paper.pdf"
+    assert why == "pdf_url"
+
+
+def test_openalex_falls_back_to_landing_page() -> None:
+    url, why = select_fetch_url(
+        canonical_url=OA,
+        provenance={"pdf_url": None,
+                    "landing_page_url": "https://host.org/page"},
+    )
+    assert url == "https://host.org/page"
+    assert why == "landing_page_url"
+
+
+def test_openalex_falls_back_to_bare_doi() -> None:
+    url, why = select_fetch_url(canonical_url=OA, doi="10.1515/pwp-2023-0031")
+    assert url == "https://doi.org/10.1515/pwp-2023-0031"
+    assert why == "doi"
+
+
+def test_openalex_doi_already_a_url() -> None:
+    url, why = select_fetch_url(
+        canonical_url=OA, doi="https://doi.org/10.1/x",
+    )
+    assert url == "https://doi.org/10.1/x"
+    assert why == "doi"
+
+
+def test_openalex_nothing_fetchable() -> None:
+    url, why = select_fetch_url(canonical_url=OA)
+    assert url is None
+    assert why == "no_fetchable_url"
+
+
+def test_openalex_alt_url_pointing_back_at_openalex_is_ignored() -> None:
+    url, why = select_fetch_url(
+        canonical_url=OA,
+        provenance={"landing_page_url": "https://openalex.org/W123"},
+    )
+    assert url is None and why == "no_fetchable_url"
+
+
+def test_none_canonical_is_passed_through() -> None:
+    url, why = select_fetch_url(canonical_url=None)
+    assert url is None and why == "canonical"
+
+
+def test_openalex_source_captures_location_urls() -> None:
+    """The OpenAlex source must surface primary_location URLs in raw so
+    the pipeline can put them into provenance."""
+    from study_scraper.discovery.openalex import OpenAlexSource
+
+    work = {
+        "id": "https://openalex.org/W999",
+        "title": "Umfrage zur Kernenergie",
+        "doi": "",
+        "language": "de",
+        "primary_location": {
+            "landing_page_url": "https://journal.example.org/a/999",
+            "pdf_url": "https://journal.example.org/a/999.pdf",
+            "source": {"display_name": "Journal"},
+        },
+    }
+    src = OpenAlexSource()
+
+    class _T:
+        id = "atomkraft"
+
+    cand = src._work_to_candidate(work, topic=_T())  # noqa: SLF001 - unit test
+    assert cand is not None
+    assert cand.raw["landing_page_url"] == "https://journal.example.org/a/999"
+    assert cand.raw["pdf_url"] == "https://journal.example.org/a/999.pdf"

--- a/tests/study_scraper/test_topics.py
+++ b/tests/study_scraper/test_topics.py
@@ -29,7 +29,10 @@ class TestLoadTopics:
         repo_root = Path(__file__).resolve().parents[2]
         topics = load_topics(repo_root / "config" / "topics" / "topics.csv")
         ids = {t.id for t in topics}
-        assert ids == {"steuern", "klima", "migration_einwanderung", "bildung"}
+        # Core topics must be present; new topics (e.g. atomkraft,
+        # added 2026-06-28) may join over time.
+        assert {"steuern", "klima", "migration_einwanderung", "bildung",
+                "atomkraft"} <= ids
         for topic in topics:
             assert "de" in topic.locales
             assert "en" in topic.locales


### PR DESCRIPTION
Works agent task #25 (filed from today's production run: 7/91 fulltext failures, all 403s on `openalex.org/W…` canonical URLs — bot-protected metadata pages that can never yield the document).

- `fulltext.select_fetch_url` (pure): non-openalex canonicals pass through; openalex URLs prefer provenance `pdf_url` → `landing_page_url` → DOI; nothing fetchable → `no_fetchable_url`.
- `run_fulltext` uses it; unfetchable studies get flagged in provenance (`storage.mark_unfetchable`) and leave the fulltext queue — no more eternal 403s. Summaries carry `fetch_url`.
- OpenAlex source now captures `primary_location.landing_page_url`/`pdf_url` into `Candidate.raw`; pipeline propagates both into `studies.provenance` (future ingests get first-class fallback URLs).
- Also repairs `test_topics` on main (the seeded-CSV equality assert broke when `atomkraft` joined the taxonomy in #19; now superset-based).

9 new pure tests; full suite **152 passed**. Closes #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_