### PR TITLE
Build #20: audit --sample-size CLI for accuracy spot-checks

### DIFF
--- a/study_scraper/cli.py
+++ b/study_scraper/cli.py
@@ -680,6 +680,47 @@ def eval_cmd(
         typer.echo(f"\nwrote {out}")
 
 
+@app.command("audit")
+def audit(
+    sample_size: int = typer.Option(
+        20, "--sample-size", help="How many random findings to show."
+    ),
+) -> None:
+    """Accuracy spot-check: print N RANDOM stored attributions with their
+    evidence (source_span, grounded flag, distribution check) and source
+    link, one block each, so a human can mark pass/fail in minutes.
+    Read-only. (ACCURACY.md measurement C.)"""
+    storage = _storage_from_settings()
+    rows = storage.sample_attributions(limit=sample_size)
+    if not rows:
+        typer.echo("(no attributions stored yet — run `attribute` first)")
+        return
+    for i, row in enumerate(rows, start=1):
+        raw = row.get("raw") or {}
+        pct = row.get("percentage")
+        pct_str = f"{float(pct):.1f}%" if pct is not None else "—"
+        grounded = raw.get("grounded")
+        grounded_str = {True: "✓ grounded", False: "✗ UNGROUNDED"}.get(
+            grounded, "— unchecked"
+        )
+        dist = raw.get("distribution_check")
+        dist_str = "  ⚠ distribution>120%" if dist is False else ""
+        conf = row.get("confidence")
+        conf_str = f"{float(conf):.2f}" if conf is not None else "—"
+        typer.echo(f"[{i}] {pct_str}  {row.get('position')}  {row.get('question')}")
+        typer.echo(f"    evidence : {raw.get('source_span') or '(no span recorded)'}")
+        typer.echo(f"    checks   : {grounded_str}  conf={conf_str}{dist_str}")
+        if row.get("population"):
+            typer.echo(f"    population: {row['population']}")
+        typer.echo(f"    source   : [{row.get('source_id')}] {row.get('title')}")
+        typer.echo(f"               {row.get('canonical_url')}")
+        typer.echo("")
+    typer.echo(
+        f"reviewed 0/{len(rows)} — mark each pass/fail; "
+        "ungrounded findings are the priority queue."
+    )
+
+
 @review_app.command("auto")
 def review_auto(
     topic: Optional[str] = typer.Option(None, "--topic"),

--- a/study_scraper/storage/postgres.py
+++ b/study_scraper/storage/postgres.py
@@ -788,6 +788,28 @@ class PostgresStorage:
                 cur.execute(f"SELECT COUNT(*) AS c FROM {SCHEMA}.attributions")
                 return int(cur.fetchone()["c"])
 
+    def sample_attributions(self, *, limit: int = 20) -> List[Dict[str, Any]]:
+        """Random sample of stored attributions with study context, for
+        the `audit` accuracy spot-check (ACCURACY.md measurement C).
+        Excludes rejected studies. Includes `raw` (source_span, grounded,
+        distribution_check live there)."""
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT a.question, a.position, a.percentage,
+                           a.population, a.confidence, a.model, a.raw,
+                           s.title, s.canonical_url, s.source_id
+                    FROM   {SCHEMA}.attributions a
+                    JOIN   {SCHEMA}.studies s ON s.id = a.study_id
+                    WHERE  s.status <> 'rejected'
+                    ORDER  BY random()
+                    LIMIT  %s
+                    """,
+                    (limit,),
+                )
+                return list(cur.fetchall())
+
     def filter_attributions(
         self,
         *,

--- a/tests/study_scraper/test_audit_cli.py
+++ b/tests/study_scraper/test_audit_cli.py
@@ -1,0 +1,89 @@
+"""Agent task #20: `audit --sample-size N` accuracy spot-check CLI."""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator
+
+import pytest
+from typer.testing import CliRunner
+
+from study_scraper.cli import app
+
+
+TEST_DSN = os.environ.get("STUDY_SCRAPER_TEST_DSN")
+
+
+def test_cli_registers_audit_command() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["audit", "--help"])
+    assert result.exit_code == 0
+    assert "--sample-size" in result.output
+    assert "spot-check" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# Integration (real Postgres)
+# ---------------------------------------------------------------------------
+
+pytestmark_integration = pytest.mark.skipif(
+    not TEST_DSN, reason="STUDY_SCRAPER_TEST_DSN not set; skipping integration"
+)
+
+
+@pytest.fixture(scope="module")
+def storage():
+    from study_scraper.storage import PostgresStorage
+    assert TEST_DSN is not None
+    store = PostgresStorage(TEST_DSN)
+    store.migrate()
+    return store
+
+
+@pytestmark_integration
+def test_sample_attributions_shape(storage) -> None:
+    from datetime import datetime, timezone
+    import json as _json
+
+    from study_scraper.attribute import apply_responses
+    from study_scraper.claims import extract_claims
+    from study_scraper.models import Provenance, Study
+
+    with storage.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE study_scraper.attributions CASCADE")
+            cur.execute("TRUNCATE study_scraper.claims CASCADE")
+            cur.execute("TRUNCATE study_scraper.crawl_run_studies CASCADE")
+            cur.execute("TRUNCATE study_scraper.studies CASCADE")
+        conn.commit()
+
+    study = Study.build(
+        canonical_url="https://example.org/audit-test",
+        title="Audit test",
+        abstract="62% befürworten ein Klimaschutzgesetz.",
+        fetched_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        source_id="openalex",
+        provenance=Provenance(discovery_source="openalex"),
+        topic_ids=["klima"],
+        topic_scores={"klima": 0.5},
+    )
+    storage.upsert_study(study)
+    claims = extract_claims(
+        study_id=study.id, title=study.title, abstract=study.abstract
+    )
+    storage.upsert_claims(study.id, claims, extractor="regex-v1")
+    response = _json.dumps({"attributions": [
+        {"question": "Stricter climate law", "position": "support",
+         "percentage": 62, "population": None, "confidence": 0.9,
+         "source_span": "62% befürworten ein Klimaschutzgesetz"},
+    ]})
+    apply_responses(storage=storage, responses={study.id: response})
+
+    rows = storage.sample_attributions(limit=5)
+    assert len(rows) == 1
+    row = rows[0]
+    for field in ("question", "position", "percentage", "confidence",
+                  "raw", "title", "canonical_url", "source_id"):
+        assert field in row
+    assert row["raw"].get("source_span")
+    assert row["raw"].get("grounded") is True


### PR DESCRIPTION
Works agent task #20 (ACCURACY.md measurement C — the weekly manual accuracy pass).

`python -m study_scraper audit --sample-size N` prints N **random** stored attributions, one human-scannable block each: %/position/question, the verbatim `source_span` evidence, the `grounded` flag (hallucination guard), distribution warning, confidence, and the source study + URL. Read-only.

- `storage.sample_attributions(limit)` — random sample joined to studies, rejected excluded, `raw` included.
- CLI registration test + DSN-gated integration test (sample shape, `grounded=True` end-to-end via `apply_responses`).

Full suite **153 passed**. Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_