### PR TITLE
Fix #26 root cause: OpenAlex search terms must be OR-joined

### DIFF
--- a/study_scraper/discovery/openalex.py
+++ b/study_scraper/discovery/openalex.py
@@ -257,8 +257,11 @@ class OpenAlexSource:
 def _build_search_query(topic: Topic) -> str:
     """Build a `search` parameter from the topic's include + synonym terms.
 
-    OpenAlex's `search` is a simple full-text match; we OR-join the
-    terms with spaces, which OpenAlex treats as a relevance query.
+    OpenAlex combines space-separated search terms with **AND** — a
+    space-joined keyword list demands a document match ALL terms at once,
+    which returned seen=0 on live runs (issue #26, observed 2026-07-02).
+    Terms must be OR-joined explicitly; multi-word terms are quoted so
+    their words stay one phrase.
     """
     terms: List[str] = []
     seen: set[str] = set()
@@ -268,10 +271,13 @@ def _build_search_query(topic: Topic) -> str:
             if not key or key in seen:
                 continue
             seen.add(key)
-            terms.append(term.strip())
+            cleaned = term.strip()
+            if " " in cleaned:
+                cleaned = f'"{cleaned}"'
+            terms.append(cleaned)
     # Cap to keep URL length sane — most relevant signal is in the first
     # half-dozen terms anyway.
-    return " ".join(terms[:8])
+    return " OR ".join(terms[:8])
 
 
 def _reconstruct_abstract(idx: Optional[Dict[str, List[int]]]) -> Optional[str]:

--- a/tests/study_scraper/test_openalex.py
+++ b/tests/study_scraper/test_openalex.py
@@ -135,6 +135,15 @@ class TestHelpers:
             for kw in ["Klimaschutz", "Energiewende", "Klimawandel", "CO2"]
         )
 
+    def test_build_search_query_or_joins_terms(self, klima) -> None:
+        # OpenAlex ANDs space-separated terms; a keyword list must be
+        # OR-joined or live queries return ~zero results (issue #26).
+        q = _build_search_query(klima)
+        assert " OR " in q
+        for chunk in q.split(" OR "):
+            # multi-word terms must be quoted phrases, not bare AND-words
+            assert " " not in chunk or chunk.startswith('"'), chunk
+
     def test_reconstruct_abstract_handles_none(self) -> None:
         assert _reconstruct_abstract(None) is None
         assert _reconstruct_abstract({}) is None


### PR DESCRIPTION
Addresses agent task #26 (root cause). Live crawls showed `openalex seen=0` across topics. **Root cause:** OpenAlex combines space-separated `search` terms with **AND**, so our space-joined keyword list demanded a document match all 8 terms simultaneously — effectively zero results ever.

`_build_search_query` now OR-joins terms explicitly and quotes multi-word terms as phrases:

`ISCED Bildungsabschluss Schulabgang …` (AND ≈ 0 hits) → `ISCED OR Bildungsabschluss OR Schulabgang OR …`

Live `seen>0` verification lands with the next scheduled crawl (Mon 05:00 UTC cron); the klima/atomkraft SSOAR-yield half of #26 stays open for the agent team. Suite **154 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_