### PR TITLE
Self-healing: auto-close recovery + ANTHROPIC_API_KEY as alternative credential

### DIFF
--- a/.github/scripts/check_agent_result.sh
+++ b/.github/scripts/check_agent_result.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 # Self-healing check for Claude agent steps (see check_agent_result.py).
 #
-# If the agent no-oped (missing output, or result.is_error=true — the
-# signature of an expired CLAUDE_CODE_OAUTH_TOKEN), this:
+# On FAILURE (agent no-oped — missing output, or result.is_error=true,
+# the signature of a dead credential):
 #   1. files or updates ONE deduped `needs-human` ops issue telling the
 #      maintainer exactly how to fix it, and
 #   2. fails the job, so the run shows RED instead of a silent green.
+# On SUCCESS: if the ops issue is open, comments "recovered" and CLOSES
+# it — the healing loop closes itself the moment a credential works
+# again; no human confirmation step.
 #
 # Requires: GH_TOKEN env (pass ${{ github.token }}), runs from repo root.
 
@@ -18,11 +21,22 @@ reason=""
 if [ ! -f "$OUT" ]; then
   reason="No Claude execution output file was produced."
 elif ! python3 .github/scripts/check_agent_result.py "$OUT"; then
-  reason="The Claude step errored immediately (is_error=true) — the usual cause is an expired or invalid CLAUDE_CODE_OAUTH_TOKEN secret."
+  reason="The Claude step errored immediately (is_error=true) — the usual cause is an expired or invalid credential (CLAUDE_CODE_OAUTH_TOKEN, or ANTHROPIC_API_KEY if you use that instead)."
 fi
 
 if [ -z "$reason" ]; then
   echo "self-healing check passed"
+  # Recovery: close the ops ticket automatically if it's still open.
+  if command -v gh >/dev/null 2>&1 && [ -n "${GH_TOKEN:-}" ]; then
+    existing=$(gh issue list -R "$GITHUB_REPOSITORY" --state open \
+      --search "$TITLE in:title" --json number --jq '.[0].number' 2>/dev/null || true)
+    if [ -n "$existing" ] && [ "$existing" != "null" ]; then
+      gh issue close "$existing" -R "$GITHUB_REPOSITORY" --comment \
+        "Recovered: workflow **${GITHUB_WORKFLOW:-?}** run ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-?} passed the self-healing check — the Claude credential works again. Closing automatically." \
+        || true
+      echo "auto-closed ops issue #$existing (recovered)"
+    fi
+  fi
   exit 0
 fi
 
@@ -32,10 +46,11 @@ BODY="Workflow **${GITHUB_WORKFLOW:-?}** (run ${GITHUB_SERVER_URL:-https://githu
 
 **Reason:** $reason
 
-**Fix (2 min):**
-1. On your computer run \`claude setup-token\` and copy the token.
-2. Repo → Settings → Secrets and variables → Actions → update \`CLAUDE_CODE_OAUTH_TOKEN\`.
-3. Re-run any agent workflow — this issue can be closed once a run passes.
+**Fix (2 min) — either credential works:**
+- *Subscription:* run \`claude setup-token\` locally, update the repo secret \`CLAUDE_CODE_OAUTH_TOKEN\` (delete it if dead and you switch to an API key).
+- *API key:* add repo secret \`ANTHROPIC_API_KEY\` (metered) — the workflows accept it as an alternative.
+
+Then re-run any agent workflow. This issue **closes itself automatically** on the first passing run.
 
 Until fixed, ALL Claude-powered workflows (agent-product / monitor / develop / review and scheduled-attribute) are silently no-oping. See docs/study_scraper/AUTONOMY.md failure modes."
 

--- a/.github/workflows/agent-develop.yml
+++ b/.github/workflows/agent-develop.yml
@@ -34,14 +34,20 @@ jobs:
         id: gate
         env:
           TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          APIKEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          [ -z "$TOKEN" ] && echo "enabled=false" >> "$GITHUB_OUTPUT" || echo "enabled=true" >> "$GITHUB_OUTPUT"
-          [ -z "$TOKEN" ] && echo "CLAUDE_CODE_OAUTH_TOKEN not set; skipping." || true
+          if [ -z "$TOKEN" ] && [ -z "$APIKEY" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "No Claude credential (CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY); skipping."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Run developer agent
         if: steps.gate.outputs.enabled == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill"'
           prompt: |
             You are the DEVELOPER agent for the study-scraper project.

--- a/.github/workflows/agent-monitor.yml
+++ b/.github/workflows/agent-monitor.yml
@@ -30,15 +30,21 @@ jobs:
         id: gate
         env:
           TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          APIKEY: ${{ secrets.ANTHROPIC_API_KEY }}
           DB: ${{ secrets.SCRAPER_POSTGRES_URL }}
         run: |
-          { [ -z "$TOKEN" ] || [ -z "$DB" ]; } && echo "enabled=false" >> "$GITHUB_OUTPUT" || echo "enabled=true" >> "$GITHUB_OUTPUT"
-          { [ -z "$TOKEN" ] || [ -z "$DB" ]; } && echo "secrets missing; skipping." || true
+          if [ -z "$DB" ] || { [ -z "$TOKEN" ] && [ -z "$APIKEY" ]; }; then
+            echo "Need SCRAPER_POSTGRES_URL plus a Claude credential; skipping."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Run monitor agent
         if: steps.gate.outputs.enabled == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: '--allowedTools "Bash,Read,Write,Glob,Grep,Skill"'
           prompt: |
             You are the MONITOR agent for the study-scraper pipeline.

--- a/.github/workflows/agent-product.yml
+++ b/.github/workflows/agent-product.yml
@@ -31,14 +31,20 @@ jobs:
         id: gate
         env:
           TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          APIKEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          [ -z "$TOKEN" ] && echo "enabled=false" >> "$GITHUB_OUTPUT" || echo "enabled=true" >> "$GITHUB_OUTPUT"
-          [ -z "$TOKEN" ] && echo "CLAUDE_CODE_OAUTH_TOKEN not set; skipping." || true
+          if [ -z "$TOKEN" ] && [ -z "$APIKEY" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "No Claude credential (CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY); skipping."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Run product-lead agent
         if: steps.gate.outputs.enabled == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill"'
           prompt: |
             You are the PRODUCT LEAD agent for the study-scraper project.

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -37,14 +37,20 @@ jobs:
         id: gate
         env:
           TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          APIKEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          [ -z "$TOKEN" ] && echo "enabled=false" >> "$GITHUB_OUTPUT" || echo "enabled=true" >> "$GITHUB_OUTPUT"
-          [ -z "$TOKEN" ] && echo "CLAUDE_CODE_OAUTH_TOKEN not set; skipping." || true
+          if [ -z "$TOKEN" ] && [ -z "$APIKEY" ]; then
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "No Claude credential (CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY); skipping."
+          else
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Run challenger agent
         if: steps.gate.outputs.enabled == 'true'
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill"'
           prompt: |
             You are the CHALLENGER agent for the study-scraper project.

--- a/.github/workflows/attribute.yml
+++ b/.github/workflows/attribute.yml
@@ -54,9 +54,10 @@ jobs:
         env:
           DB: ${{ secrets.SCRAPER_POSTGRES_URL }}
           TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          APIKEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          if [ -z "$DB" ] || [ -z "$TOKEN" ]; then
-            echo "SCRAPER_POSTGRES_URL and/or CLAUDE_CODE_OAUTH_TOKEN not set; skipping."
+          if [ -z "$DB" ] || { [ -z "$TOKEN" ] && [ -z "$APIKEY" ]; }; then
+            echo "Need SCRAPER_POSTGRES_URL plus a Claude credential (CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY); skipping."
             echo "enabled=false" >> "$GITHUB_OUTPUT"
           else
             echo "enabled=true" >> "$GITHUB_OUTPUT"
@@ -72,6 +73,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           # Allow the file + shell tools the skill needs; no network tools
           # beyond what the CLI already permits.
           claude_args: '--allowedTools "Bash,Read,Write,Glob,Grep,Skill"'


### PR DESCRIPTION
Closes the healing loop in **both directions** and widens the revival path:

- `check_agent_result.sh`: on a **passing** run, if the ops ticket (#24) is open it comments "recovered" and **closes it automatically** — open on failure, close on recovery, zero human confirmation.
- All five Claude workflows now accept **`ANTHROPIC_API_KEY`** as an alternative to `CLAUDE_CODE_OAUTH_TOKEN` (gates enable on either credential; the action receives both inputs). Two revival paths instead of one.
- Ops-ticket body updated to describe both options + the auto-close.

Scripts re-tested (success → exit 0, failure → exit 1); all 5 workflow YAMLs validate; suite **154 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_