### PR TITLE
Answer-layer statistics fix + product-agent source scouting

### DIFF
--- a/.claude/skills/product-direction/SKILL.md
+++ b/.claude/skills/product-direction/SKILL.md
@@ -48,7 +48,13 @@ gh label create needs-human   --color d93f0b --description "Requires a human dec
    `agent:task` issue with a `priority:*` label and a short, testable
    acceptance criterion. Don't flood — at most a few high-value tasks per
    run; prefer updating existing ones.
-7. **Sync the roadmap.** Update `docs/study_scraper/ROADMAP.md` (create if
+7. **Scout new sources (each run).** WebSearch for German data
+   platforms we don't cover yet (e.g. 'offene Daten Umfrage Deutschland
+   API <topic>', 'Meinungsforschung Datensatz frei'). Vet 1–2 candidates
+   — free? structured? licence? — and add promising ones to the ROADMAP
+   source plan or file an `agent:task`. Coverage breadth is a standing
+   product goal.
+8. **Sync the roadmap.** Update `docs/study_scraper/ROADMAP.md` (create if
    missing) on a branch and open a normal PR (label `agent:review` so the
    challenger merges it). NEVER push to main.
 

--- a/.github/workflows/agent-product.yml
+++ b/.github/workflows/agent-product.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill"'
+          claude_args: '--allowedTools "Bash,Read,Write,Edit,Glob,Grep,Skill,WebSearch,WebFetch"'
           prompt: |
             You are the PRODUCT LEAD agent for the study-scraper project.
             Use the project skill `.claude/skills/product-direction/SKILL.md`
@@ -57,7 +57,11 @@ jobs:
             maintainer (@cfischa) 1–3 crisp questions. Read any of their
             prior replies and incorporate them. Convert agreed direction
             into prioritized issues labeled `agent:task` (+ priority:high/
-            med/low) for the developer agent, and keep docs/study_scraper/
+            med/low) for the developer agent. Each run, also SCOUT for new
+            German data platforms (WebSearch: e.g. 'deutsche Umfragedaten
+            offene Daten API <topic>'); vet 1-2 candidates (free? structured?
+            licence?) and add promising ones to the ROADMAP source plan or
+            as an agent:task. Keep docs/study_scraper/
             ROADMAP.md in sync via a normal PR (do NOT push to main; do NOT
             edit .github/** or .claude/**). Be decisive and concise.
 

--- a/docs/study_scraper/ROADMAP.md
+++ b/docs/study_scraper/ROADMAP.md
@@ -36,6 +36,24 @@ installs/curation · **[done]** shipped.
    refetch, store `ETag`/`Last-Modified` and send conditional GETs
    (304 → skip). Standard incremental-crawl practice.
 
+## Answer-layer statistics — correctness upgrades (audited 2026-07-04)
+
+A. **Population in dedup identity** **[done 2026-07-04]** — same
+   question+% among different populations no longer merge.
+B. **Recency-aware answers** **[now, small]** — `ask` now shows the year;
+   next: order deduped findings by publication_date (newest first) on
+   confidence ties, and let `ask --since 2024` filter stale polls.
+C. **Sample-size context** **[now, small]** — we extract `n=` claims but
+   don't attach them to findings; join the study's sample-size claim to
+   its attributions so answers can show "(n=1004, 2026)".
+D. **Poll-of-polls aggregation** **[larger]** — a real "what does Germany
+   think about X" answer aggregates across institutes: recency- and
+   sample-size-weighted average per (question-cluster, position) with a
+   spread indicator, instead of a list of single findings.
+E. **Semantic question clustering** **[larger, embeddings]** — 'Atomausstieg
+   rückgängig machen' and 'return to nuclear power' should cluster; lexical
+   ILIKE misses them. Prereq for D at scale.
+
 ## Source-coverage plan — toward a representative platform
 
 Current coverage: **catalog** SSOAR + OpenAlex (academic); **lake** DAWUM
@@ -53,7 +71,11 @@ statistics breadth*. Ranked by yield per effort:
 7. **BASE** **[now]** — OAI-PMH academic aggregator (Bielefeld);
    reuses the SSOAR OAI parser almost verbatim; widens the catalog far
    beyond SSOAR. Fixture + unit tests, no live call in CI.
-8. **Polling-institute press releases** **[now, larger]** — Forsa, INSA,
+8. **Domain-audit source discovery** (issue #37) **[now]** — Phase 5d:
+   walk stored study/reference URLs, group unknown domains, surface them
+   as candidate sources (report + dock list). Plus: the product agent now
+   scouts via WebSearch each run.
+9. **Polling-institute press releases** **[now, larger]** — Forsa, INSA,
    infratest dimap (ARD-DeutschlandTrend), Allensbach, YouGov DE, Civey
    publish issue-polls as HTML/PDF press pages. One config-driven
    `SitemapSource` (per-publisher YAML: sitemap/listing URL + selectors),

--- a/docs/study_scraper/ROADMAP.md
+++ b/docs/study_scraper/ROADMAP.md
@@ -36,7 +36,7 @@ installs/curation · **[done]** shipped.
    refetch, store `ETag`/`Last-Modified` and send conditional GETs
    (304 → skip). Standard incremental-crawl practice.
 
-## Answer-layer statistics — correctness upgrades (audited 2026-07-04)
+## Answer-layer statistics — correctness upgrades (audited 2026-07-04; B+C = issue #39)
 
 A. **Population in dedup identity** **[done 2026-07-04]** — same
    question+% among different populations no longer merge.
@@ -71,7 +71,7 @@ statistics breadth*. Ranked by yield per effort:
 7. **BASE** **[now]** — OAI-PMH academic aggregator (Bielefeld);
    reuses the SSOAR OAI parser almost verbatim; widens the catalog far
    beyond SSOAR. Fixture + unit tests, no live call in CI.
-8. **Domain-audit source discovery** (issue #37) **[now]** — Phase 5d:
+8. **Domain-audit source discovery** (issue #38) **[now]** — Phase 5d:
    walk stored study/reference URLs, group unknown domains, surface them
    as candidate sources (report + dock list). Plus: the product agent now
    scouts via WebSearch each run.

--- a/study_scraper/cli.py
+++ b/study_scraper/cli.py
@@ -386,7 +386,9 @@ def ask(
         dup = row.get("dup_count") or 1
         if dup > 1:
             q = f"{q}  (+{dup - 1} more)"
-        typer.echo(f"{pct_str}  {pos}  {q}")
+        pub = row.get("publication_date")
+        year = f" [{pub.year}]" if pub else ""
+        typer.echo(f"{pct_str}  {pos}  {q}{year}")
         title = (row.get("title") or "").replace("\n", " ")
         if len(title) > 70:
             title = title[:67] + "..."

--- a/study_scraper/findings.py
+++ b/study_scraper/findings.py
@@ -29,9 +29,17 @@ def dedup_finding_key(
     question: Optional[str],
     position: Optional[str],
     percentage: Optional[float],
-) -> Tuple[str, str, Optional[int]]:
+    population: Optional[str] = None,
+) -> Tuple[str, str, Optional[int], str]:
     """Identity of a finding for dedup. Percentage rounds to the nearest
-    whole point so 61.6% and 62% collapse; None stays distinct."""
+    whole point so 61.6% and 62% collapse; None stays distinct.
+
+    `population` is part of the identity: the same question+% among
+    "Ostdeutsche" and among "Wahlberechtigte ab 18" are DIFFERENT
+    findings and must not merge (statistical-correctness fix,
+    2026-07-04). None/blank populations normalize to "" so unlabeled
+    findings still dedup against each other.
+    """
     pos = (position or "unspecified").strip().lower()
     pct: Optional[int]
     if percentage is None:
@@ -41,7 +49,8 @@ def dedup_finding_key(
             pct = int(round(float(percentage)))
         except (TypeError, ValueError):
             pct = None
-    return (_norm_question(question), pos, pct)
+    pop = re.sub(r"\s+", " ", (population or "").lower()).strip()
+    return (_norm_question(question), pos, pct, pop)
 
 
 def _confidence(row: Dict[str, Any]) -> float:
@@ -75,13 +84,14 @@ def dedupe_attributions(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     Input order of distinct findings is preserved (first appearance wins
     the slot), so an already-sorted list stays sorted.
     """
-    best: Dict[Tuple[str, str, Optional[int]], Dict[str, Any]] = {}
-    counts: Dict[Tuple[str, str, Optional[int]], int] = {}
-    order: List[Tuple[str, str, Optional[int]]] = []
+    best: Dict[Tuple[str, str, Optional[int], str], Dict[str, Any]] = {}
+    counts: Dict[Tuple[str, str, Optional[int], str], int] = {}
+    order: List[Tuple[str, str, Optional[int], str]] = []
 
     for row in rows:
         key = dedup_finding_key(
-            row.get("question"), row.get("position"), row.get("percentage")
+            row.get("question"), row.get("position"),
+            row.get("percentage"), row.get("population"),
         )
         counts[key] = counts.get(key, 0) + 1
         if key not in best:

--- a/tests/study_scraper/test_findings_dedup.py
+++ b/tests/study_scraper/test_findings_dedup.py
@@ -15,7 +15,7 @@ def _row(q, pos, pct, conf, grounded=None, title="t"):
 
 def test_key_rounds_percentage_to_whole_point() -> None:
     assert dedup_finding_key("Q", "support", 61.6) == dedup_finding_key("Q", "support", 62.0)
-    assert dedup_finding_key("Q", "support", 62) == ("q", "support", 62)
+    assert dedup_finding_key("Q", "support", 62) == ("q", "support", 62, "")
 
 
 def test_key_normalizes_question_whitespace_case() -> None:
@@ -74,3 +74,23 @@ def test_dedupe_grounded_breaks_confidence_tie() -> None:
 
 def test_empty_input() -> None:
     assert dedupe_attributions([]) == []
+
+
+def test_different_populations_do_not_merge() -> None:
+    # Statistical correctness: same question+% among different populations
+    # are DIFFERENT findings (e.g. East vs West Germany).
+    rows = [
+        {**_row("Tempolimit", "support", 60, 0.8), "population": "Ostdeutsche"},
+        {**_row("Tempolimit", "support", 60, 0.9), "population": "Westdeutsche"},
+    ]
+    out = dedupe_attributions(rows)
+    assert len(out) == 2
+
+
+def test_blank_and_none_population_still_merge() -> None:
+    rows = [
+        {**_row("Q", "support", 50, 0.6), "population": None},
+        {**_row("Q", "support", 50, 0.9), "population": "  "},
+    ]
+    out = dedupe_attributions(rows)
+    assert len(out) == 1 and out[0]["confidence"] == 0.9


### PR DESCRIPTION
**Statistical correctness** (maintainer audit request): the dedup identity now includes the normalized **population** — the same question+% among "Ostdeutsche" vs. all voters are *different findings* and no longer merge (previously they collapsed to one row, silently dropping a real finding). `ask` also shows each finding's **publication year** for recency visibility. 2 new tests; suite **165 passed**.

**Coverage breadth:** the product-lead agent gains **WebSearch/WebFetch** and a standing **source-scouting duty** (vet 1–2 German data platforms per run → ROADMAP/`agent:task`).

**ROADMAP:** new "Answer-layer statistics" plan (recency ordering, sample-size context on findings, poll-of-polls aggregation, semantic question clustering) + domain-audit discovery elevated with an issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_