### PR TITLE
Product expansion: poll-of-polls answers, monitoring digest, dossiers, Bundestag DIP + opinion–policy gap, open dataset export

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -109,10 +109,23 @@ jobs:
           python -m study_scraper status
           python -m study_scraper status --json > scrape-status.json
 
+      - name: Opinion digest (monitoring v1)
+        if: steps.gate.outputs.enabled == 'true'
+        env:
+          POSTGRES_URL: ${{ secrets.SCRAPER_POSTGRES_URL }}
+        run: |
+          # Aggregates every active watch (see `watch add`), reports
+          # shifts >=5pts and newly tracked questions vs the previous
+          # digest, and stores the new snapshot in the DB.
+          python -m study_scraper digest --out opinion-digest.md || true
+          cat opinion-digest.md || true
+
       - name: Upload status artifact
         if: steps.gate.outputs.enabled == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: scrape-status-${{ github.run_id }}
-          path: scrape-status.json
+          path: |
+            scrape-status.json
+            opinion-digest.md
           retention-days: 30

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -59,6 +59,7 @@ jobs:
         if: steps.gate.outputs.enabled == 'true'
         env:
           POSTGRES_URL: ${{ secrets.SCRAPER_POSTGRES_URL }}
+          DIP_API_KEY: ${{ secrets.DIP_API_KEY }}
         run: |
           set +e  # one failing/slow source must not kill the others
           # Topics come from config/topics/topics.csv — adding a topic row
@@ -71,6 +72,10 @@ jobs:
           for topic in $TOPICS; do
             timeout 900 python -m study_scraper run --source ssoar    --topic "$topic" --limit 400
             timeout 900 python -m study_scraper run --source openalex --topic "$topic" --limit 400
+            # Bundestag DIP (opinion-policy gap, parliament half). Uses
+            # the published public API key unless DIP_API_KEY is set as
+            # a repo secret (recommended; the public key rotates).
+            timeout 600 python -m study_scraper run --source bundestag_dip --topic "$topic" --limit 200
           done
           timeout 600 python -m study_scraper ingest --source dawum
           timeout 600 python -m study_scraper ingest --source gesis --limit 500

--- a/README.md
+++ b/README.md
@@ -42,9 +42,18 @@ python -m study_scraper ingest --source gesis    --topic klima   # see docs
 
 # Query the data
 python -m study_scraper search klimaschutzgesetz   # extracted claims
-python -m study_scraper search atomkraft
+python -m study_scraper ask    klimaschutzgesetz   # structured findings (llm-v1)
+python -m study_scraper answer atomkraft           # poll-of-polls aggregate
 python -m study_scraper view   dawum_poll_results   # SQL view over the lake
 python -m study_scraper status
+
+# Products over the answer layer (2026-07-05)
+python -m study_scraper watch add klimagesetz --label "Climate law"
+python -m study_scraper digest --out digest.md      # shifts + novelties per watch
+python -m study_scraper dossier atomkraft --out dossier.md   # citable report
+python -m study_scraper gaps                        # evidence-gap table per topic
+python -m study_scraper policy-gap --topic klima    # opinion vs Bundestag DIP
+python -m study_scraper export --out dataset/       # open CSV dataset
 
 # Streamlit operator dock (status overview + topic editor + review queue)
 streamlit run study_scraper/console/Home.py

--- a/docs/study_scraper/ROADMAP.md
+++ b/docs/study_scraper/ROADMAP.md
@@ -40,19 +40,42 @@ installs/curation · **[done]** shipped.
 
 A. **Population in dedup identity** **[done 2026-07-04]** — same
    question+% among different populations no longer merge.
-B. **Recency-aware answers** **[now, small]** — `ask` now shows the year;
-   next: order deduped findings by publication_date (newest first) on
-   confidence ties, and let `ask --since 2024` filter stale polls.
-C. **Sample-size context** **[now, small]** — we extract `n=` claims but
-   don't attach them to findings; join the study's sample-size claim to
-   its attributions so answers can show "(n=1004, 2026)".
-D. **Poll-of-polls aggregation** **[larger]** — a real "what does Germany
-   think about X" answer aggregates across institutes: recency- and
-   sample-size-weighted average per (question-cluster, position) with a
-   spread indicator, instead of a list of single findings.
-E. **Semantic question clustering** **[larger, embeddings]** — 'Atomausstieg
-   rückgängig machen' and 'return to nuclear power' should cluster; lexical
-   ILIKE misses them. Prereq for D at scale.
+B. **Recency-aware answers** **[done 2026-07-05]** — `ask --since YEAR`;
+   dedup representative prefers newer publication on confidence ties.
+C. **Sample-size context** **[done 2026-07-05]** — the study's
+   representative n= claim joins its attributions; `ask` shows
+   "[2025, n=1009]". (Also fixed: % and n= claims from the same
+   sentence used to collide on claim id and the n was dropped.)
+D. **Poll-of-polls aggregation** **[done 2026-07-05]** — `answer <q>`:
+   recency- (3y half-life) and sample-size- (sqrt(n/1000), clamped)
+   weighted mean per (question-cluster, position) with spread, poll
+   count, year range, Σn. Never a lone number.
+E. **Semantic question clustering** **[done 2026-07-05, v1 offline]** —
+   `clustering.py`: bilingual concept-map token cosine, greedy
+   single-linkage; 'Atomausstieg rückgängig machen' and 'return to
+   nuclear power' cluster. `embedder=` hook ready for a real embedding
+   backend (pgvector) later. German queries reach English-normalized
+   questions via the same map (`search_attributions_semantic`).
+
+## Product-expansion build (2026-07-05; see notes/product-expansion-2026-07-04.md)
+
+- **Monitoring v1** **[done]** — migration 0009 `watches` +
+  `watch_snapshots`; `watch add/list/rm`; `digest` reports ≥5pt shifts
+  and newly tracked questions vs the previous snapshot; scheduled
+  workflow uploads `opinion-digest.md` per run.
+- **Research dossier** **[done]** — `dossier <q> [--out]`: citable
+  Markdown (summary, per-finding table, method caveats, provenance).
+- **Evidence-gap report** **[done]** — `gaps [--topic]`: per question
+  cluster the freshness/breadth flags (stale, single source, no
+  percentages).
+- **Opinion–policy gap** **[done, v1 juxtaposition]** — `policy-gap
+  --topic X`: aggregated opinion vs ingested Bundestag DIP Drucksachen.
+  Per-question → bill matching is the v2 once DIP coverage grows.
+- **Open dataset export** **[done]** — `export --out DIR`: findings.csv
+  + studies.csv + manifest; facts and links only.
+- **Next**: real embedding backend for E; demographic breakdowns
+  (population_segment); opinion⇄fact joins (needs Eurostat typed
+  views, P1.3); public read-only surface (gated on gold-set eval).
 
 ## Source-coverage plan — toward a representative platform
 
@@ -65,9 +88,11 @@ statistics breadth*. Ranked by yield per effort:
    standing opinion survey; free, structured, includes Germany, directly
    answers "what do people think about X". Lake source; data via the EC
    open-data portal / GESIS mirrors.
-6. **Bundestag DIP API** **[needs-human: free API key by email]** —
-   parliamentary documents (Drucksachen/Plenarprotokolle) frequently cite
-   polling; structured JSON REST. Catalog-style source.
+6. **Bundestag DIP API** **[done 2026-07-05]** —
+   `discovery/bundestag_dip.py`, catalog-style, fixture-tested; in the
+   scheduled crawl. Runs on the Bundestag's published public API key;
+   set the `DIP_API_KEY` secret with a personal key (free by mail to
+   infoline.id3@bundestag.de) when the public one rotates out.
 7. **BASE** **[now]** — OAI-PMH academic aggregator (Bielefeld);
    reuses the SSOAR OAI parser almost verbatim; widens the catalog far
    beyond SSOAR. Fixture + unit tests, no live call in CI.

--- a/docs/study_scraper/RUNBOOK.md
+++ b/docs/study_scraper/RUNBOOK.md
@@ -230,6 +230,22 @@ streamlit run study_scraper/console/Home.py
 4. **Lake** — spot-check new structured records.
 5. CLI: `reading-list` → pick studies to read; `search <begriff>` →
    answer questions.
+6. **Answer-layer products (2026-07-05)**: `answer <q>` for the
+   aggregated poll-of-polls view; `digest` after each crawl (or read
+   the `opinion-digest.md` workflow artifact) for shifts/novelties on
+   your watches (`watch add <q>` to register one); `gaps` to see which
+   question clusters are stale or single-sourced; `policy-gap --topic
+   <id>` for the opinion-vs-Bundestag view; `dossier <q> --out f.md`
+   when someone needs a citable report; `export --out dataset/` for
+   the open CSV dump.
+
+### 5.1 Credentials the products can use (all optional)
+
+| Secret / env | Used by | Without it |
+| --- | --- | --- |
+| `SCRAPER_POSTGRES_URL` (repo secret) | scheduled crawl + digest | workflow exits early, green |
+| `DIP_API_KEY` | Bundestag DIP source | falls back to the published public key (rotates yearly) |
+| `ANTHROPIC_API_KEY` | live `attribute` | use the offline Cowork path (§3.5b) |
 
 ## 6. What is NOT done (honest list, also in TODO.md)
 

--- a/docs/study_scraper/STATUS.md
+++ b/docs/study_scraper/STATUS.md
@@ -1,10 +1,45 @@
 # Status — independent analysis of the repo
 
-_Last updated: 2026-06-15 (A21: llm-v1 attribution extractor — the
-answer layer turning claims into (question, position, %) triples, with
-a live Option-A path and a zero-cost Cowork offline path. **233 tests
-pass.** Remaining work is machine-bound; the exact local steps are in
-[`RUNBOOK.md`](RUNBOOK.md) §0.)._
+_Last updated: 2026-07-05 (product-expansion build: answer-layer
+B/C/D/E complete, monitoring digest, dossier + gap reports, Bundestag
+DIP + opinion–policy gap, open dataset export. **392 tests pass**,
+full loop verified end-to-end against a real Postgres.)_
+
+## Product-expansion pass (2026-07-05)
+
+Everything buildable from the strategy note
+(`notes/product-expansion-2026-07-04.md`) shipped in one pass:
+
+1. **Answer-layer correctness finished** — ROADMAP B (recency:
+   `ask --since`, newer-poll dedup ties), C (sample size joined to
+   findings: "[2025, n=1009]"), plus a real bug found on the way: %
+   and n= claims from the same sentence collided on claim id, so
+   sample sizes never reached the DB.
+2. **Clustering (E) + aggregation (D)** — `clustering.py` (bilingual
+   concept cosine, pluggable embedder) and `aggregate.py`; new CLI
+   `answer` prints the weighted poll-of-polls view with spread.
+3. **Monitoring v1** — migration 0009 (`watches`, `watch_snapshots`),
+   `watch add/list/rm`, `digest` (≥5pt shift + novelty detection,
+   Markdown artifact in the scheduled workflow).
+4. **Dossier / gaps / policy-gap** — citable per-question Markdown
+   dossier; per-topic evidence-gap table; opinion vs Bundestag-DIP
+   juxtaposition (`policy-gap --topic X`).
+5. **Bundestag DIP source** — catalog-style, fixture-tested, in the
+   scheduled crawl (public API key default, `DIP_API_KEY` override).
+6. **Open dataset export** — findings.csv + studies.csv + manifest.
+
+Verified end-to-end on a local Postgres: 6-source fixture ingest →
+claims → offline attribution (24 triples over 9 studies) → ask/answer
+(German queries hit English questions via the semantic fallback) →
+digest snapshot cycle (baseline → shift detection → settles at 0 news)
+→ dossier/gaps/policy-gap/export. Three real defects found by the
+production run and fixed with regression tests (claim-id collision,
+ILIKE language miss, cluster over-merge at concept weight 3).
+
+**Machine-bound remainder:** live crawl + fulltext need outbound
+network (the dev environment's proxy policy blocks non-registry
+hosts); scheduled production needs the `SCRAPER_POSTGRES_URL` secret
+(RUNBOOK §1.1), optionally `DIP_API_KEY` and `ANTHROPIC_API_KEY`.
 
 ## Attribution pass (2026-06-15, A21)
 

--- a/docs/study_scraper/notes/product-expansion-2026-07-04.md
+++ b/docs/study_scraper/notes/product-expansion-2026-07-04.md
@@ -1,0 +1,193 @@
+# Product expansion — from Q&A tool to democratic-infrastructure platform
+
+_Note, 2026-07-04. Maintainer prompt: "For now it's answering questions
+on user input. With the data we could monitor, complete research, and so
+on — what else to do on the product/data side, and which use cases could
+be relevant to push a pro-democratic society?"_
+
+This note maps the expansion space on top of what already exists (the
+coverage-first scraper, the claims/attributions answer layer, the
+scheduled Mon+Thu crawl, the operator dock) and ends with a recommended
+sequence. It is direction input, not a backlog — items that get accepted
+should be broken into `agent:task` issues / ROADMAP entries the usual way.
+
+## Where the product is today
+
+One interaction mode: **pull**. A user (or the CLI) asks a question and
+gets back deduplicated (question, position, %) findings with source,
+year, and provenance — `ask "climate"` → `62.0% support · Stricter
+climate laws`. The data underneath is broader than the interaction
+surface exposes: a studies catalog with a citation graph, a
+structured-data lake (DAWUM vote intention, GESIS survey catalog,
+Eurostat indicators), full-text claims, attributions, and per-run crawl
+bookkeeping. The expansion question is therefore mostly: **what other
+products does the same data already support?**
+
+## Axis 1 — from pull to push: opinion monitoring
+
+The scheduled crawl already runs twice a week; today its output is a
+status artifact nobody reads unless something breaks (the monitor agent
+watches *pipeline* health, not *data* meaning). The cheapest expansion
+is to make each crawl produce meaning, not just rows:
+
+1. **Standing questions ("watches").** A `watches` table: a user
+   registers a question (a topic id + free-text question, later a
+   question-cluster id). After each crawl+attribution run, new findings
+   matching a watch are collected into a digest. Delivery v1 = a
+   Markdown digest committed to the repo / posted to a GitHub issue
+   (zero new infra); email/RSS later.
+2. **Shift detection.** Once findings for the same question-cluster
+   form a time series, flag movements: "support for Wiedereinstieg
+   Atomkraft moved 55% → 61% between March and June polls". This is
+   the single most newsworthy artifact the data can produce and it
+   falls out of ROADMAP items D+E (poll-of-polls + semantic
+   clustering) almost for free.
+3. **Novelty alerts.** "First poll ever ingested on topic X",
+   "publisher never seen before", "new poll contradicts the standing
+   aggregate by >10 points". The last one doubles as a data-quality
+   tripwire (extraction error vs real outlier — the dock reviews it).
+4. **Per-topic weekly briefing.** Auto-generated per-topic page: new
+   studies this week, new numbers, current aggregate, biggest mover.
+   The Streamlit dock is the operator's view; the briefing is the
+   *reader's* view and can be a static artifact (committed Markdown or
+   generated HTML) long before any hosted product exists.
+
+## Axis 2 — from single answers to completed research
+
+`ask` returns a list of findings. The step up is returning a **synthesis**
+— what a researcher would assemble by hand:
+
+5. **Research dossier per question.** For one policy question: all
+   findings clustered semantically, aggregated recency- and
+   sample-size-weighted (ROADMAP D), spread across institutes shown
+   explicitly, methodology notes (mode, n, fieldwork window, question
+   wording where captured), qualitative studies listed alongside, and
+   a provenance appendix. Output: a cited Markdown report. This turns
+   an answer into something a journalist or NGO can actually cite.
+6. **Evidence-gap map per topic.** The inverse product, and unique to
+   a coverage-first store: which questions on a topic have been polled,
+   by whom, how recently — and where the holes are (no data since
+   2022, single-institute only, qualitative-only). Nobody else in the
+   German landscape publishes this; it tells civil society *what poll
+   to commission next*.
+7. **Consensus/contradiction analysis.** Where institutes durably
+   disagree on the same question-cluster, surface it, and with enough
+   overlapping questions estimate house effects (institute-level
+   bias), the way poll-of-polls sites do for vote intention — but for
+   *issue* polling, where nobody does it.
+8. **Longitudinal question tracking.** Politbarometer/ALLBUS have
+   asked identical questions for decades; GESIS is already a source.
+   "Support for X, 1990–2026" charts are high-credibility artifacts
+   and pure downstream SQL once microdata/toplines are in the lake.
+
+## Axis 3 — data-side foundations these need
+
+Ordered by how many of the above they unblock:
+
+- **Semantic question clustering (ROADMAP E)** is the keystone.
+  Watches, shift detection, dossiers, gap maps, and house effects all
+  require knowing that "Atomausstieg rückgängig machen" and "return to
+  nuclear power" are the same question. pgvector + a small embedding
+  model on `attributions.question` is enough for v1.
+- **Poll-of-polls aggregation (ROADMAP D)** — the answer object
+  becomes (cluster, position, weighted %, spread, n_polls, date range)
+  instead of a finding list.
+- **Demographic breakdowns.** Studies routinely report splits (age,
+  party preference, East/West). Extending the attribution schema with
+  an optional `population_segment` dimension (the population-dedup
+  work from A-item 2026-07-04 already points here) unlocks
+  representation-gap analysis, which is where the democratic value
+  concentrates.
+- **Opinion ⇄ fact joins.** Eurostat/Destatis rows are *indicators*,
+  not opinions — their value is juxtaposition: "X% believe crime is
+  rising; recorded crime is falling". Needs the typed Eurostat views
+  (ROADMAP P1.3) plus a curated mapping from topics to indicator codes.
+- **Finding-level trust score.** Sample size, method, recency,
+  institute track record → a displayed confidence grade per finding.
+  The dock trust signals (#21) started this; it must be *visible in
+  answers* before anything is shown to non-operators.
+- **Open dataset export.** A versioned CSV/Parquet dump (or read-only
+  API) of `attributions` + `studies` metadata. Cheap, and it turns the
+  project from a tool into infrastructure others build on.
+
+## Axis 4 — pro-democratic use cases (the "why")
+
+The thread through all of these: **public opinion in Germany is
+constantly asserted and rarely verifiable.** Politicians cite friendly
+polls, media cherry-pick, paywalled archives (Allensbach etc.) hide the
+record, and no open, provenance-backed archive of issue-poll findings
+exists. The scraper's provenance-first design is exactly the missing
+piece. Concrete use cases, roughly in order of leverage:
+
+1. **The opinion–policy gap tracker.** Join majority opinion per
+   question-cluster with what parliament actually does (Bundestag DIP
+   is already ROADMAP item 6: Drucksachen, votes, structured JSON).
+   "70% support X; the corresponding bill failed in committee" is the
+   canonical democratic-accountability artifact. This should be the
+   flagship — it is unique, entirely in-scope for the existing data
+   model, and both halves are already planned sources.
+2. **Fact-checking public-opinion claims.** "Most Germans want …" is
+   one of the most-abused rhetorical moves in German politics. A
+   journalist pastes the claim, gets the actual distribution of
+   findings with spread, n, and links. This is `ask` + dossier + a
+   thin public surface; it counters manufactured-majority narratives
+   ("die schweigende Mehrheit") with sourced data.
+3. **Poll-literacy transparency.** Because the store keeps method,
+   n, fieldwork dates, and question wording, every answer can *show
+   why polls differ* (Civey's opt-in river sampling vs infratest's
+   probability samples; wording effects). Displaying uncertainty
+   honestly is itself civic education and is what separates this from
+   advocacy tooling.
+4. **Representation audits.** With demographic breakdowns: whose
+   preferences do enacted policies track — by age, income, region?
+   The academic version (Elsässer/Schäfer for Germany, Gilens for the
+   US) is famous and years out of date; a continuously updated open
+   version would be genuinely new.
+5. **Evidence base for deliberative processes.** Bürgerräte, citizen
+   assemblies, and NGOs need "what is known about public opinion on
+   our topic" as briefing input. The dossier (item 5) is precisely
+   that document, and the gap map tells them what's *not* known.
+6. **An open longitudinal archive.** Simply persisting every published
+   topline with provenance, forever, in the open — findings otherwise
+   scattered across press releases that rot — is a public good on its
+   own, before any analysis layer.
+
+## Principles and risks (read before building any public surface)
+
+- **Non-partisanship is the product.** The democratic value comes from
+  provenance and methodological transparency, never from editorial
+  framing. Always show spread and dissent, never a lone number;
+  publish the methodology of the aggregation itself.
+- **Accuracy before reach.** A wrong percentage published under a
+  democracy banner is worse than no product. The answer-layer
+  correctness items (recency B, sample-size C, aggregation D) and a
+  real gold-set accuracy number (P3.13) are hard gates before any
+  non-operator surface ships.
+- **Legal shape.** Republishing facts (toplines, %, n) with citation
+  is safe ground; redistributing full texts or bulk-mirroring
+  databases is not (Leistungsschutzrecht, sui-generis database
+  rights). The export should stay at findings + metadata + links,
+  which is what the schema stores anyway.
+- **Election-period sensitivity.** Vote-intention aggregation near
+  elections has extra scrutiny (and Wahlrecht §32-adjacent norms on
+  exit polls). Issue polling is the differentiator anyway — DAWUM
+  already covers horse-race numbers; stay focused on issues.
+
+## Recommended sequence
+
+1. **Finish answer-layer correctness** (ROADMAP B, C — small, [now])
+   and **semantic clustering E**, then **aggregation D**. Everything
+   above stands on these.
+2. **Monitoring v1** on the existing cron: watches table + per-topic
+   Markdown digest + shift/novelty flags. Cheap, uses only existing
+   infra, and creates the first recurring reader-facing artifact.
+3. **Bundestag DIP source + opinion–policy gap view** — the flagship
+   democratic use case; both halves already on the roadmap.
+4. **Dossier generator** (reuses the aggregation + digest machinery)
+   and the **evidence-gap report**.
+5. **Public read-only surface + open dataset export** — only after the
+   gold-set eval reports a real accuracy number.
+
+Step 2's watches/digest and step 4's dossier are also the natural first
+consumers for the demographic-breakdown and opinion⇄fact extensions, so
+schema work can trail the products rather than lead them.

--- a/study_scraper/aggregate.py
+++ b/study_scraper/aggregate.py
@@ -1,0 +1,182 @@
+"""Poll-of-polls aggregation (ROADMAP item D).
+
+A real "what does Germany think about X" answer is not a list of single
+findings — it aggregates across institutes: a recency- and sample-size-
+weighted average per (question-cluster, position), with the spread shown
+honestly. Non-partisanship rule from the product-expansion note: always
+show spread and poll count, never a lone number.
+
+Pure functions over deduped attribution rows (the same rows `ask`
+displays); clustering comes from `clustering.py`. Read-time, no
+migration — the raw audit trail is untouched.
+
+Weights:
+  - recency: half-life of 3 years on the study's publication date
+    (a 2022 poll counts half a 2025 poll). Undated studies are treated
+    as `_UNDATED_AGE_YEARS` old — included, but nearly voiceless.
+  - sample size: sqrt(n / 1000) clamped to [0.3, 3.0]; unknown n = 1.0.
+    sqrt because information grows sub-linearly in n; the clamp stops a
+    single mega-panel from drowning every other institute.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from study_scraper.clustering import DEFAULT_THRESHOLD, cluster_attributions
+
+_HALF_LIFE_YEARS = 3.0
+_UNDATED_AGE_YEARS = 8.0
+_REFERENCE_N = 1000.0
+
+
+def _age_years(pub: Optional[_dt.date], today: _dt.date) -> float:
+    if pub is None:
+        return _UNDATED_AGE_YEARS
+    if isinstance(pub, _dt.datetime):
+        pub = pub.date()
+    return max(0.0, (today - pub).days / 365.25)
+
+
+def recency_weight(pub: Optional[_dt.date], today: _dt.date) -> float:
+    return 0.5 ** (_age_years(pub, today) / _HALF_LIFE_YEARS)
+
+
+def sample_weight(n: Optional[float]) -> float:
+    if n is None or n <= 0:
+        return 1.0
+    return min(3.0, max(0.3, (float(n) / _REFERENCE_N) ** 0.5))
+
+
+@dataclass
+class PositionAggregate:
+    """One (question-cluster, position) cell of the answer."""
+
+    position: str
+    weighted_pct: float
+    min_pct: float
+    max_pct: float
+    n_findings: int
+    year_min: Optional[int]
+    year_max: Optional[int]
+    total_sample: Optional[int]   # sum of known n; None if none known
+    findings: List[Dict[str, Any]] = field(repr=False, default_factory=list)
+
+    @property
+    def spread(self) -> float:
+        return self.max_pct - self.min_pct
+
+
+@dataclass
+class ClusterAnswer:
+    """The aggregate answer for one question cluster."""
+
+    label: str
+    positions: List[PositionAggregate]
+    n_findings: int
+
+    def get(self, position: str) -> Optional[PositionAggregate]:
+        for p in self.positions:
+            if p.position == position:
+                return p
+        return None
+
+
+def aggregate_findings(
+    rows: List[Dict[str, Any]],
+    *,
+    today: Optional[_dt.date] = None,
+    threshold: float = DEFAULT_THRESHOLD,
+) -> List[ClusterAnswer]:
+    """Cluster deduped attribution rows and aggregate per position.
+
+    Rows without a percentage are skipped (they can't average). Clusters
+    come back largest-first; positions within a cluster in the fixed
+    support/oppose/neutral/unspecified order.
+    """
+    today = today or _dt.date.today()
+    usable = [r for r in rows if r.get("percentage") is not None]
+    if not usable:
+        return []
+
+    clustered = cluster_attributions(usable, threshold=threshold)
+    groups: Dict[Tuple[int, str], List[Dict[str, Any]]] = {}
+    labels: Dict[int, str] = {}
+    for row in clustered:
+        cid = row["cluster_id"]
+        labels[cid] = row["cluster_label"]
+        key = (cid, row.get("position") or "unspecified")
+        groups.setdefault(key, []).append(row)
+
+    by_cluster: Dict[int, List[PositionAggregate]] = {}
+    for (cid, position), members in groups.items():
+        w_sum = 0.0
+        wx_sum = 0.0
+        pcts: List[float] = []
+        years: List[int] = []
+        samples: List[int] = []
+        for m in members:
+            pct = float(m["percentage"])
+            w = recency_weight(m.get("publication_date"), today) * sample_weight(
+                m.get("sample_size")
+            )
+            w_sum += w
+            wx_sum += w * pct
+            pcts.append(pct)
+            pub = m.get("publication_date")
+            if pub is not None:
+                years.append(pub.year)
+            n = m.get("sample_size")
+            if n is not None:
+                samples.append(int(n))
+        by_cluster.setdefault(cid, []).append(
+            PositionAggregate(
+                position=position,
+                weighted_pct=wx_sum / w_sum if w_sum else 0.0,
+                min_pct=min(pcts),
+                max_pct=max(pcts),
+                n_findings=len(members),
+                year_min=min(years) if years else None,
+                year_max=max(years) if years else None,
+                total_sample=sum(samples) if samples else None,
+                findings=members,
+            )
+        )
+
+    position_order = {"support": 0, "oppose": 1, "neutral": 2, "unspecified": 3}
+    answers: List[ClusterAnswer] = []
+    for cid, positions in by_cluster.items():
+        positions.sort(key=lambda p: position_order.get(p.position, 9))
+        answers.append(
+            ClusterAnswer(
+                label=labels[cid],
+                positions=positions,
+                n_findings=sum(p.n_findings for p in positions),
+            )
+        )
+    answers.sort(key=lambda a: -a.n_findings)
+    return answers
+
+
+def format_answer(answer: ClusterAnswer) -> str:
+    """One cluster as human-readable CLI text."""
+    lines = [f"Q: {answer.label}"]
+    for p in answer.positions:
+        bits = [f"{p.n_findings} poll{'s' if p.n_findings != 1 else ''}"]
+        if p.n_findings > 1:
+            bits.append(f"spread {p.min_pct:.0f}–{p.max_pct:.0f}%")
+        if p.year_min is not None:
+            years = (
+                str(p.year_max)
+                if p.year_min == p.year_max
+                else f"{p.year_min}–{p.year_max}"
+            )
+            bits.append(years)
+        if p.total_sample is not None:
+            bits.append(f"Σn={p.total_sample:,}")
+        lines.append(
+            f"   {p.position:<11} {p.weighted_pct:5.1f}%   ({', '.join(bits)})"
+        )
+    return "\n".join(lines)

--- a/study_scraper/claims.py
+++ b/study_scraper/claims.py
@@ -91,8 +91,18 @@ class ExtractedClaim:
 
     @property
     def id(self) -> str:
-        """Stable id so re-extraction is idempotent."""
-        key = f"{self.study_id}|{self.source_field}|{self.claim_text}"
+        """Stable id so re-extraction is idempotent.
+
+        Unit and value are part of the identity: a % claim and an n=
+        claim extracted from the SAME sentence share their snippet, and
+        without them the second insert hit ON CONFLICT DO NOTHING and
+        was silently dropped (bug found 2026-07-05 — sample sizes never
+        reached the DB when they shared a sentence with the finding).
+        """
+        key = (
+            f"{self.study_id}|{self.source_field}|{self.claim_text}"
+            f"|{self.unit}|{self.numeric_value}"
+        )
         return hashlib.sha256(key.encode("utf-8")).hexdigest()
 
 

--- a/study_scraper/cli.py
+++ b/study_scraper/cli.py
@@ -656,6 +656,60 @@ def view(
         typer.echo(line)
 
 
+@app.command()
+def dossier(
+    query: str = typer.Argument(
+        ..., help="The policy question, as keyword(s) matched against "
+                  "attribution questions."
+    ),
+    since: Optional[int] = typer.Option(
+        None, "--since", help="Only findings from this year or later."
+    ),
+    out: Optional[Path] = typer.Option(
+        None, "--out", help="Write the Markdown dossier here (else stdout)."
+    ),
+) -> None:
+    """Research dossier: one policy question rendered as a citable
+    Markdown report — poll-of-polls summary, every finding with year /
+    n / population / institute, methodology caveats, and a provenance
+    appendix. What a journalist or NGO would assemble by hand."""
+    from study_scraper.dossier import build_dossier
+
+    storage = _storage_from_settings()
+    text = build_dossier(storage, query, since=since)
+    if out is not None:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text, encoding="utf-8")
+        typer.echo(f"wrote {out}")
+    else:
+        typer.echo(text)
+
+
+@app.command()
+def gaps(
+    topic: Optional[str] = typer.Option(
+        None, "--topic", help="Limit to one topic id (default: all attributed)."
+    ),
+    out: Optional[Path] = typer.Option(
+        None, "--out", help="Write the Markdown report here (else stdout)."
+    ),
+) -> None:
+    """Evidence-gap report: per topic, which question clusters have
+    data, how fresh and how broadly sourced — and where the holes are
+    (stale, single-source, no percentages). The coverage-first store's
+    unique product: it shows what we DON'T know."""
+    from study_scraper.dossier import build_gap_report
+
+    storage = _storage_from_settings()
+    text = build_gap_report(storage, topic=topic)
+    if out is not None:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text, encoding="utf-8")
+        typer.echo(f"wrote {out}")
+    else:
+        typer.echo(text)
+
+
 watch_app = typer.Typer(
     help="Standing questions for the monitoring digest (product Axis 1).",
     no_args_is_help=True,

--- a/study_scraper/cli.py
+++ b/study_scraper/cli.py
@@ -124,9 +124,14 @@ def run(
         ctx = SSOARSource(from_file=from_file)
     elif source == "openalex":
         ctx = OpenAlexSource(from_file=from_file)
+    elif source == "bundestag_dip":
+        from study_scraper.discovery.bundestag_dip import BundestagDIPSource
+
+        ctx = BundestagDIPSource(from_file=from_file)
     else:
         raise typer.BadParameter(
-            f"unknown source {source!r}; supported: ssoar, openalex"
+            f"unknown source {source!r}; supported: ssoar, openalex, "
+            f"bundestag_dip"
         )
     topic_obj = _load_topic(topic)
     storage = _storage_from_settings()
@@ -697,6 +702,30 @@ def dossier(
 
     storage = _storage_from_settings()
     text = build_dossier(storage, query, since=since)
+    if out is not None:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text, encoding="utf-8")
+        typer.echo(f"wrote {out}")
+    else:
+        typer.echo(text)
+
+
+@app.command("policy-gap")
+def policy_gap(
+    topic: str = typer.Option(..., "--topic", help="Topic id from topics.csv."),
+    out: Optional[Path] = typer.Option(
+        None, "--out", help="Write the Markdown report here (else stdout)."
+    ),
+) -> None:
+    """Opinion–policy gap: what the polls say on a topic next to what
+    the Bundestag is doing on it (DIP Drucksachen). The flagship
+    democratic-accountability view — strong majorities with no
+    parliamentary activity (or activity against the majority) are the
+    gaps."""
+    from study_scraper.dossier import build_policy_gap_report
+
+    storage = _storage_from_settings()
+    text = build_policy_gap_report(storage, topic=topic)
     if out is not None:
         out.parent.mkdir(parents=True, exist_ok=True)
         out.write_text(text, encoding="utf-8")

--- a/study_scraper/cli.py
+++ b/study_scraper/cli.py
@@ -409,6 +409,43 @@ def ask(
 
 
 @app.command()
+def answer(
+    query: str = typer.Argument(
+        ..., help="Keyword(s) matched against attribution questions."
+    ),
+    since: Optional[int] = typer.Option(
+        None, "--since",
+        help="Only findings from studies published in this year or later.",
+    ),
+    limit: int = typer.Option(
+        10, "--limit", help="Max question clusters to print."
+    ),
+) -> None:
+    """Poll-of-polls answer (ROADMAP D): aggregate matching findings
+    across institutes into a recency- and sample-size-weighted average
+    per question cluster, with the spread shown honestly. Where `ask`
+    lists findings, `answer` synthesizes them.
+    """
+    from study_scraper.aggregate import aggregate_findings, format_answer
+
+    storage = _storage_from_settings()
+    rows = storage.search_attributions_deduped(
+        query=query, limit=500, since=since
+    )
+    answers = aggregate_findings(rows)
+    if not answers:
+        typer.echo("(no findings with percentages matched — run `attribute` first?)")
+        return
+    for a in answers[:limit]:
+        typer.echo(format_answer(a))
+        typer.echo("")
+    typer.echo(
+        "method: weighted mean per question cluster; weights = recency "
+        "(3y half-life) × sqrt(n/1000) clamped to [0.3, 3]."
+    )
+
+
+@app.command()
 def attribute(
     limit: int = typer.Option(
         20, "--limit", help="Max queued studies to attribute."

--- a/study_scraper/cli.py
+++ b/study_scraper/cli.py
@@ -657,6 +657,26 @@ def view(
 
 
 @app.command()
+def export(
+    out: Path = typer.Option(
+        Path("dataset"), "--out",
+        help="Directory for findings.csv / studies.csv / manifest.json.",
+    ),
+) -> None:
+    """Export the findings layer as an open dataset: published toplines
+    with provenance (findings.csv), study metadata (studies.csv), and a
+    manifest. Facts + links only — no abstracts or full texts."""
+    from study_scraper.export import run_export
+
+    storage = _storage_from_settings()
+    manifest = run_export(storage, out)
+    typer.echo(
+        f"wrote {out}/: {manifest['findings']} findings, "
+        f"{manifest['studies']} studies"
+    )
+
+
+@app.command()
 def dossier(
     query: str = typer.Argument(
         ..., help="The policy question, as keyword(s) matched against "

--- a/study_scraper/cli.py
+++ b/study_scraper/cli.py
@@ -382,7 +382,7 @@ def ask(
     """
     storage = _storage_from_settings()
     rows = (
-        storage.search_attributions_deduped(query=query, limit=limit, since=since)
+        storage.search_attributions_semantic(query=query, limit=limit, since=since)
         if dedup
         else storage.search_attributions(query=query, limit=limit, since=since)
     )
@@ -434,7 +434,7 @@ def answer(
     from study_scraper.aggregate import aggregate_findings, format_answer
 
     storage = _storage_from_settings()
-    rows = storage.search_attributions_deduped(
+    rows = storage.search_attributions_semantic(
         query=query, limit=500, since=since
     )
     answers = aggregate_findings(rows)

--- a/study_scraper/cli.py
+++ b/study_scraper/cli.py
@@ -364,6 +364,11 @@ def ask(
         help="Collapse the same finding across studies to one "
              "confidence-weighted representative (default on).",
     ),
+    since: Optional[int] = typer.Option(
+        None, "--since",
+        help="Only findings from studies published in this year or "
+             "later (undated studies are excluded).",
+    ),
 ) -> None:
     """Query structured attributions (question, position, %) — the
     llm-v1 answer layer (A21). Richer than `search`: each hit names the
@@ -372,8 +377,9 @@ def ask(
     """
     storage = _storage_from_settings()
     rows = (
-        storage.search_attributions_deduped(query=query, limit=limit)
-        if dedup else storage.search_attributions(query=query, limit=limit)
+        storage.search_attributions_deduped(query=query, limit=limit, since=since)
+        if dedup
+        else storage.search_attributions(query=query, limit=limit, since=since)
     )
     if not rows:
         typer.echo("(no attributions matched — run `attribute` first?)")
@@ -387,8 +393,14 @@ def ask(
         if dup > 1:
             q = f"{q}  (+{dup - 1} more)"
         pub = row.get("publication_date")
-        year = f" [{pub.year}]" if pub else ""
-        typer.echo(f"{pct_str}  {pos}  {q}{year}")
+        ctx_bits = []
+        if pub:
+            ctx_bits.append(str(pub.year))
+        n = row.get("sample_size")
+        if n is not None:
+            ctx_bits.append(f"n={int(n)}")
+        ctx = f" [{', '.join(ctx_bits)}]" if ctx_bits else ""
+        typer.echo(f"{pct_str}  {pos}  {q}{ctx}")
         title = (row.get("title") or "").replace("\n", " ")
         if len(title) > 70:
             title = title[:67] + "..."

--- a/study_scraper/cli.py
+++ b/study_scraper/cli.py
@@ -656,6 +656,89 @@ def view(
         typer.echo(line)
 
 
+watch_app = typer.Typer(
+    help="Standing questions for the monitoring digest (product Axis 1).",
+    no_args_is_help=True,
+)
+app.add_typer(watch_app, name="watch")
+
+
+@watch_app.command("add")
+def watch_add(
+    query: str = typer.Argument(
+        ..., help="Keyword(s) matched against attribution questions."
+    ),
+    label: Optional[str] = typer.Option(
+        None, "--label", help="Human-readable heading for the digest."
+    ),
+    since: Optional[int] = typer.Option(
+        None, "--since", help="Only findings from this year or later."
+    ),
+) -> None:
+    """Register a standing question. Each `digest` run aggregates its
+    findings and reports shifts/novelties against the previous run."""
+    storage = _storage_from_settings()
+    watch_id = storage.add_watch(query=query, label=label, since_year=since)
+    typer.echo(f"watch {watch_id} active: {label or query!r}")
+
+
+@watch_app.command("list")
+def watch_list(
+    all_: bool = typer.Option(
+        False, "--all", help="Include deactivated watches."
+    ),
+) -> None:
+    """List watches."""
+    storage = _storage_from_settings()
+    rows = storage.list_watches(active_only=not all_)
+    if not rows:
+        typer.echo("(no watches — add one with `watch add <query>`)")
+        return
+    for row in rows:
+        state = "active" if row["active"] else "off"
+        since = f" since={row['since_year']}" if row.get("since_year") else ""
+        label = f"  — {row['label']}" if row.get("label") else ""
+        typer.echo(f"{row['id']:>3}  [{state:<6}] {row['query']!r}{since}{label}")
+
+
+@watch_app.command("rm")
+def watch_rm(watch_id: int = typer.Argument(...)) -> None:
+    """Deactivate a watch (snapshot history is kept)."""
+    storage = _storage_from_settings()
+    changed = storage.remove_watch(watch_id)
+    typer.echo("deactivated" if changed else "no change (unknown or already off)")
+
+
+@app.command()
+def digest(
+    out: Optional[Path] = typer.Option(
+        None, "--out", help="Write the Markdown digest here (else stdout)."
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run",
+        help="Compute without saving snapshots (repeatable preview).",
+    ),
+) -> None:
+    """Run the monitoring digest over all active watches: aggregate each
+    standing question, report shifts (≥5 pts) and newly tracked
+    questions vs the previous digest, store the new snapshot. Designed
+    to run after each scheduled crawl."""
+    from study_scraper.digest import format_digest_markdown, run_digest
+
+    storage = _storage_from_settings()
+    digests = run_digest(storage, save=not dry_run)
+    text = format_digest_markdown(digests)
+    if out is not None:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(text, encoding="utf-8")
+        news = sum(1 for d in digests if d.has_news)
+        typer.echo(
+            f"wrote {out} — {len(digests)} watch(es), {news} with news"
+        )
+    else:
+        typer.echo(text)
+
+
 review_app = typer.Typer(
     help="Human review of pending candidates (Q12 review queue).",
     no_args_is_help=True,

--- a/study_scraper/clustering.py
+++ b/study_scraper/clustering.py
@@ -1,0 +1,215 @@
+"""Semantic question clustering (ROADMAP item E, v1).
+
+'Atomausstieg rückgängig machen' and 'return to nuclear power' are the
+same survey question; lexical ILIKE misses that, and the aggregation
+layer (item D) cannot exist without grouping them. This module clusters
+attribution questions at READ time — no migration, raw rows untouched,
+same pattern as `findings.py`.
+
+Two similarity backends:
+
+  - **Default (offline, deterministic):** weighted-token cosine over
+    normalized tokens, where tokens that map to a known political
+    concept (bilingual DE/EN map below) carry extra weight. German
+    compounds are decomposed by substring ("klimaschutzgesetz" emits
+    both "climate" and "law"). Zero dependencies, stable across runs —
+    reproducibility is a project dimension (GOAL.md #3).
+  - **Pluggable embedder:** pass `embedder=` (a callable mapping a list
+    of strings to dense vectors) to swap in a real embedding model /
+    pgvector later without touching call sites.
+
+Clustering is greedy single-linkage in input order with a similarity
+threshold: deterministic given the same rows in the same order, which
+callers guarantee by ordering in SQL.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from collections import Counter
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence
+
+# Similarity at or above this joins a cluster. Tuned on the repo's real
+# examples: 'Atomausstieg rückgängig machen' vs 'return to nuclear
+# power' scores ~0.82; 'stricter climate laws' vs 'EU climate priority'
+# (different questions, same topic) scores ~0.62 and must NOT merge.
+DEFAULT_THRESHOLD = 0.72
+
+# Bilingual concept map: any token CONTAINING a key (compound-safe)
+# emits the canonical concept token(s). Weighted heavier than plain
+# tokens so the load-bearing word dominates the cosine.
+_CONCEPTS: Dict[str, List[str]] = {
+    "atomkraft": ["nuclear"],
+    "atomenergie": ["nuclear"],
+    "atomausstieg": ["nuclear"],
+    "kernenergie": ["nuclear"],
+    "kernkraft": ["nuclear"],
+    "nuclear": ["nuclear"],
+    "klima": ["climate"],
+    "climate": ["climate"],
+    "tempolimit": ["speedlimit"],
+    "speed": ["speedlimit"],
+    "migration": ["migration"],
+    "einwanderung": ["migration"],
+    "zuwanderung": ["migration"],
+    "immigration": ["migration"],
+    "asyl": ["asylum"],
+    "asylum": ["asylum"],
+    "rente": ["pension"],
+    "pension": ["pension"],
+    "steuer": ["tax"],
+    "tax": ["tax"],
+    "miete": ["housing"],
+    "wohnung": ["housing"],
+    "housing": ["housing"],
+    "verteidigung": ["defense"],
+    "defense": ["defense"],
+    "defence": ["defense"],
+    "bundeswehr": ["defense"],
+    "wehrpflicht": ["conscription"],
+    "conscription": ["conscription"],
+    "gesetz": ["law"],
+    "law": ["law"],
+    "verbot": ["ban"],
+    "ban": ["ban"],
+    "energie": ["energy"],
+    "energy": ["energy"],
+    "kohle": ["coal"],
+    "coal": ["coal"],
+    "erneuerbar": ["renewable"],
+    "renewable": ["renewable"],
+}
+_CONCEPT_WEIGHT = 3.0
+
+_STOPWORDS = frozenset(
+    """
+    the a an of to in for on and or should be is are was were do does
+    germany german germans its it this that with about more most
+    der die das den dem des ein eine einen einem einer und oder soll
+    sollte sollten ist sind war waren fuer mit ueber mehr sich
+    machen werden wieder wollen will
+    """.split()
+)
+
+
+def _fold(text: str) -> str:
+    """Lowercase + fold umlauts/accents so 'rückgängig' == 'ruckgangig'."""
+    text = text.lower().replace("ß", "ss")
+    text = unicodedata.normalize("NFKD", text)
+    return "".join(c for c in text if not unicodedata.combining(c))
+
+
+def _tokens(question: str) -> List[str]:
+    return [t for t in re.split(r"[^a-z0-9]+", _fold(question)) if t]
+
+
+def question_vector(question: str) -> Dict[str, float]:
+    """Sparse weighted-token vector for the default similarity backend."""
+    vec: Dict[str, float] = {}
+    for tok in _tokens(question):
+        if tok in _STOPWORDS or len(tok) < 2:
+            continue
+        # Naive singular: 'laws' -> 'law'. Applied before concept lookup
+        # so plural forms still hit the map.
+        if len(tok) > 3 and tok.endswith("s") and not tok.endswith("ss"):
+            tok = tok[:-1]
+        concepts = [c for key, cs in _CONCEPTS.items() if key in tok for c in cs]
+        if concepts:
+            for c in concepts:
+                vec[c] = vec.get(c, 0.0) + _CONCEPT_WEIGHT
+        else:
+            vec[tok] = vec.get(tok, 0.0) + 1.0
+    return vec
+
+
+def _cosine_sparse(a: Dict[str, float], b: Dict[str, float]) -> float:
+    if not a or not b:
+        return 0.0
+    dot = sum(w * b.get(t, 0.0) for t, w in a.items())
+    if dot == 0.0:
+        return 0.0
+    na = sum(w * w for w in a.values()) ** 0.5
+    nb = sum(w * w for w in b.values()) ** 0.5
+    return dot / (na * nb)
+
+
+def _cosine_dense(a: Sequence[float], b: Sequence[float]) -> float:
+    dot = sum(x * y for x, y in zip(a, b))
+    na = sum(x * x for x in a) ** 0.5
+    nb = sum(x * x for x in b) ** 0.5
+    if na == 0.0 or nb == 0.0:
+        return 0.0
+    return dot / (na * nb)
+
+
+def question_similarity(a: str, b: str) -> float:
+    """Similarity in [0, 1] under the default offline backend."""
+    return _cosine_sparse(question_vector(a), question_vector(b))
+
+
+def cluster_questions(
+    questions: Sequence[str],
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+    embedder: Optional[Callable[[List[str]], List[Sequence[float]]]] = None,
+) -> List[int]:
+    """Assign each question a cluster id (0-based, in order of first
+    appearance). Greedy single-linkage: a question joins the first
+    cluster containing ANY member at/above `threshold`, else starts a
+    new one. Deterministic for a fixed input order."""
+    if embedder is not None:
+        dense = embedder(list(questions))
+        vectors: List[Any] = list(dense)
+        sim = _cosine_dense
+    else:
+        vectors = [question_vector(q) for q in questions]
+        sim = _cosine_sparse  # type: ignore[assignment]
+
+    assignments: List[int] = []
+    members_by_cluster: List[List[int]] = []
+    for i, _q in enumerate(questions):
+        placed = False
+        for cluster_id, members in enumerate(members_by_cluster):
+            if any(sim(vectors[i], vectors[j]) >= threshold for j in members):
+                assignments.append(cluster_id)
+                members.append(i)
+                placed = True
+                break
+        if not placed:
+            assignments.append(len(members_by_cluster))
+            members_by_cluster.append([i])
+    return assignments
+
+
+def cluster_attributions(
+    rows: Iterable[Dict[str, Any]],
+    *,
+    threshold: float = DEFAULT_THRESHOLD,
+    embedder: Optional[Callable[[List[str]], List[Sequence[float]]]] = None,
+) -> List[Dict[str, Any]]:
+    """Annotate attribution rows with `cluster_id` and `cluster_label`.
+
+    The label is the most common question phrasing in the cluster
+    (shortest on ties) — a human-readable canonical form. Rows come back
+    in input order with the two keys added; raw rows are not mutated.
+    """
+    rows = list(rows)
+    questions = [(r.get("question") or "") for r in rows]
+    ids = cluster_questions(questions, threshold=threshold, embedder=embedder)
+
+    by_cluster: Dict[int, Counter] = {}
+    for cid, q in zip(ids, questions):
+        by_cluster.setdefault(cid, Counter())[q] += 1
+    labels = {
+        cid: min(counter.items(), key=lambda kv: (-kv[1], len(kv[0])))[0]
+        for cid, counter in by_cluster.items()
+    }
+
+    out: List[Dict[str, Any]] = []
+    for row, cid in zip(rows, ids):
+        annotated = dict(row)
+        annotated["cluster_id"] = cid
+        annotated["cluster_label"] = labels[cid]
+        out.append(annotated)
+    return out

--- a/study_scraper/clustering.py
+++ b/study_scraper/clustering.py
@@ -71,6 +71,12 @@ _CONCEPTS: Dict[str, List[str]] = {
     "conscription": ["conscription"],
     "gesetz": ["law"],
     "law": ["law"],
+    # 'plant/kraftwerk' keeps "build new nuclear power plants" from
+    # merging with the general "use nuclear power" question (over-merge
+    # observed on real data, 2026-07-05: 32% and 65% averaged to a
+    # meaningless 48.5%).
+    "kraftwerk": ["plant"],
+    "plant": ["plant"],
     "verbot": ["ban"],
     "ban": ["ban"],
     "energie": ["energy"],
@@ -80,7 +86,12 @@ _CONCEPTS: Dict[str, List[str]] = {
     "erneuerbar": ["renewable"],
     "renewable": ["renewable"],
 }
-_CONCEPT_WEIGHT = 3.0
+# 2.0, not 3.0: at weight 3 the shared concept dominates short
+# questions so hard that nine distinct climate questions merged into
+# one cluster on real data (2026-07-05). At 2.0 the ROADMAP DE/EN
+# example still clusters (0.73) while 'ambitious climate policy' vs
+# 'climate protection is an important task' separates (0.67).
+_CONCEPT_WEIGHT = 2.0
 
 _STOPWORDS = frozenset(
     """
@@ -146,6 +157,34 @@ def _cosine_dense(a: Sequence[float], b: Sequence[float]) -> float:
 def question_similarity(a: str, b: str) -> float:
     """Similarity in [0, 1] under the default offline backend."""
     return _cosine_sparse(question_vector(a), question_vector(b))
+
+
+# Looser than the clustering threshold: search wants recall (ranked),
+# clustering wants precision (grouped).
+SEARCH_THRESHOLD = 0.35
+
+
+def semantic_filter(
+    query: str,
+    rows: Iterable[Dict[str, Any]],
+    *,
+    threshold: float = SEARCH_THRESHOLD,
+    key: str = "question",
+) -> List[Dict[str, Any]]:
+    """Rank rows by concept similarity between `query` and row[key].
+
+    The answer layer normalizes questions to English, so a German query
+    ('klimaschutzgesetz') misses them under ILIKE. The concept map folds
+    both languages into shared tokens, letting the query match anyway.
+    Returns matching rows best-first; rows below `threshold` drop."""
+    qv = question_vector(query)
+    scored: List[tuple] = []
+    for i, row in enumerate(rows):
+        sim = _cosine_sparse(qv, question_vector(row.get(key) or ""))
+        if sim >= threshold:
+            scored.append((-sim, i, row))
+    scored.sort(key=lambda t: (t[0], t[1]))
+    return [row for _sim, _i, row in scored]
 
 
 def cluster_questions(

--- a/study_scraper/digest.py
+++ b/study_scraper/digest.py
@@ -1,0 +1,216 @@
+"""Monitoring v1 digest — the reader-facing artifact of each crawl.
+
+For every active watch (a standing question registered with `watch
+add`), each `digest` run:
+
+  1. pulls the watch's current deduped findings,
+  2. aggregates them (poll-of-polls, `aggregate.py`),
+  3. compares against the watch's PREVIOUS snapshot:
+       - **shift**: same (question-cluster, position) moved by at least
+         `SHIFT_POINTS` percentage points,
+       - **new question**: a cluster with no counterpart last time,
+       - **new findings**: the finding count grew,
+  4. stores the new snapshot and renders a Markdown section.
+
+Cluster matching between runs is fuzzy (`question_similarity`) because
+a cluster's label is its most common phrasing and can drift as new
+polls arrive.
+
+Delivery v1 is a Markdown file (committed / uploaded as a CI artifact
+by the scheduled workflow) — zero new infrastructure, per the
+product-expansion note. The digest never prints a lone number: shifts
+carry both endpoints, aggregates carry poll counts.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from study_scraper.aggregate import ClusterAnswer, aggregate_findings
+from study_scraper.clustering import DEFAULT_THRESHOLD, question_similarity
+
+SHIFT_POINTS = 5.0
+
+
+@dataclass
+class WatchDigest:
+    watch_id: int
+    query: str
+    label: str
+    findings_count: int
+    previous_count: int
+    answers: List[ClusterAnswer] = field(repr=False)
+    shifts: List[Dict[str, Any]] = field(default_factory=list)
+    new_questions: List[str] = field(default_factory=list)
+    first_run: bool = False
+
+    @property
+    def has_news(self) -> bool:
+        return bool(
+            self.shifts
+            or self.new_questions
+            or self.findings_count > self.previous_count
+        )
+
+
+def _flatten(answers: List[ClusterAnswer]) -> List[Dict[str, Any]]:
+    """Snapshot payload: one row per (cluster, position)."""
+    rows: List[Dict[str, Any]] = []
+    for a in answers:
+        for p in a.positions:
+            rows.append(
+                {
+                    "cluster_label": a.label,
+                    "position": p.position,
+                    "weighted_pct": round(p.weighted_pct, 1),
+                    "n_findings": p.n_findings,
+                }
+            )
+    return rows
+
+
+def _match_prev(
+    label: str, position: str, prev_rows: List[Dict[str, Any]]
+) -> Optional[Dict[str, Any]]:
+    """Find last run's row for this (cluster, position), label-fuzzy."""
+    best: Tuple[float, Optional[Dict[str, Any]]] = (0.0, None)
+    for row in prev_rows:
+        if row.get("position") != position:
+            continue
+        sim = question_similarity(label, row.get("cluster_label") or "")
+        if sim > best[0]:
+            best = (sim, row)
+    return best[1] if best[0] >= DEFAULT_THRESHOLD else None
+
+
+def digest_watch(
+    storage: Any,
+    watch: Dict[str, Any],
+    *,
+    today: Optional[_dt.date] = None,
+    save: bool = True,
+) -> WatchDigest:
+    """Compute one watch's digest and (by default) persist the snapshot."""
+    rows = storage.search_attributions_deduped(
+        query=watch["query"], limit=500, since=watch.get("since_year")
+    )
+    answers = aggregate_findings(rows, today=today)
+    current = _flatten(answers)
+
+    prev_snapshot = storage.latest_watch_snapshot(watch["id"])
+    prev_rows = list(prev_snapshot["payload"]) if prev_snapshot else []
+    prev_count = int(prev_snapshot["findings_count"]) if prev_snapshot else 0
+
+    shifts: List[Dict[str, Any]] = []
+    new_questions: List[str] = []
+    seen_labels: set = set()
+    for row in current:
+        label = row["cluster_label"]
+        prev = _match_prev(label, row["position"], prev_rows)
+        if prev is None:
+            if prev_snapshot is not None and label not in seen_labels:
+                new_questions.append(label)
+        else:
+            delta = row["weighted_pct"] - float(prev["weighted_pct"])
+            if abs(delta) >= SHIFT_POINTS:
+                shifts.append(
+                    {
+                        "cluster_label": label,
+                        "position": row["position"],
+                        "from_pct": float(prev["weighted_pct"]),
+                        "to_pct": row["weighted_pct"],
+                        "delta": round(delta, 1),
+                    }
+                )
+        seen_labels.add(label)
+
+    if save:
+        storage.save_watch_snapshot(
+            watch["id"], findings_count=len(rows), payload=current
+        )
+
+    return WatchDigest(
+        watch_id=watch["id"],
+        query=watch["query"],
+        label=watch.get("label") or watch["query"],
+        findings_count=len(rows),
+        previous_count=prev_count,
+        answers=answers,
+        shifts=shifts,
+        new_questions=sorted(set(new_questions)),
+        first_run=prev_snapshot is None,
+    )
+
+
+def run_digest(
+    storage: Any, *, today: Optional[_dt.date] = None, save: bool = True
+) -> List[WatchDigest]:
+    """Digest every active watch, in watch-id order."""
+    return [
+        digest_watch(storage, watch, today=today, save=save)
+        for watch in storage.list_watches()
+    ]
+
+
+def format_digest_markdown(
+    digests: List[WatchDigest], *, generated_at: Optional[_dt.datetime] = None
+) -> str:
+    """The full digest as Markdown — the deliverable of a digest run."""
+    from study_scraper.aggregate import format_answer
+
+    ts = (generated_at or _dt.datetime.now(_dt.timezone.utc)).strftime(
+        "%Y-%m-%d %H:%M UTC"
+    )
+    lines: List[str] = [f"# Opinion digest — {ts}", ""]
+    if not digests:
+        lines.append("_No active watches. Register one with `watch add`._")
+        return "\n".join(lines) + "\n"
+
+    for d in digests:
+        lines.append(f"## {d.label}")
+        lines.append("")
+        if d.first_run:
+            lines.append(
+                f"_First digest for this watch — baseline snapshot of "
+                f"{d.findings_count} finding(s) stored; shifts appear from "
+                f"the next run._"
+            )
+        else:
+            delta = d.findings_count - d.previous_count
+            lines.append(
+                f"{d.findings_count} finding(s) "
+                f"({'+' if delta >= 0 else ''}{delta} since last digest)."
+            )
+        lines.append("")
+        for s in d.shifts:
+            arrow = "▲" if s["delta"] > 0 else "▼"
+            lines.append(
+                f"- **{arrow} shift**: *{s['cluster_label']}* ({s['position']}) "
+                f"moved {s['from_pct']:.1f}% → {s['to_pct']:.1f}% "
+                f"({s['delta']:+.1f} pts)"
+            )
+        for q in d.new_questions:
+            lines.append(f"- **new question tracked**: *{q}*")
+        if d.shifts or d.new_questions:
+            lines.append("")
+        if d.answers:
+            lines.append("```")
+            for a in d.answers[:10]:
+                lines.append(format_answer(a))
+                lines.append("")
+            if lines[-1] == "":
+                lines.pop()
+            lines.append("```")
+        else:
+            lines.append("_(no findings with percentages yet)_")
+        lines.append("")
+
+    lines.append("---")
+    lines.append(
+        "_Method: weighted mean per question cluster; weights = recency "
+        "(3-year half-life) × sqrt(n/1000) clamped to [0.3, 3]. Shifts "
+        f"reported at ≥ {SHIFT_POINTS:.0f} points._"
+    )
+    return "\n".join(lines) + "\n"

--- a/study_scraper/digest.py
+++ b/study_scraper/digest.py
@@ -93,7 +93,7 @@ def digest_watch(
     save: bool = True,
 ) -> WatchDigest:
     """Compute one watch's digest and (by default) persist the snapshot."""
-    rows = storage.search_attributions_deduped(
+    rows = storage.search_attributions_semantic(
         query=watch["query"], limit=500, since=watch.get("since_year")
     )
     answers = aggregate_findings(rows, today=today)

--- a/study_scraper/discovery/bundestag_dip.py
+++ b/study_scraper/discovery/bundestag_dip.py
@@ -1,0 +1,229 @@
+"""Bundestag DIP discovery — parliamentary documents per topic.
+
+ROADMAP source #6 and one half of the flagship democratic use case
+(product-expansion Axis 4): the opinion–policy gap view joins majority
+opinion per question cluster with what parliament actually debates and
+decides. This source ingests the parliament half: Drucksachen
+(Anträge, Gesetzentwürfe, Antworten) matched to topic keywords, as
+catalog-style candidates flowing through the normal topic filter.
+
+API: DIP (Dokumentations- und Informationssystem für Parlamentsmaterialien),
+`https://search.dip.bundestag.de/api/v1` — structured JSON REST.
+
+Auth: an API key sent as the `apikey` query parameter. The Bundestag
+PUBLISHES a shared public key in the API documentation
+(https://dip.bundestag.de/über-dip/hilfe/api) and rotates it every year
+or two; a personal key is free by mail to infoline.id3@bundestag.de.
+Resolution order here: explicit `api_key=` arg → `DIP_API_KEY` env var
+→ the published public key below (may age out — then set DIP_API_KEY).
+
+Two modes share one parser (house pattern):
+  1. Live — GET /drucksache with `f.titel` per topic keyword,
+     cursor-paginated.
+  2. Fixture (`from_file=`) — a saved JSON response; test path and
+     no-network environments.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import date, datetime
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional
+
+import httpx
+
+from study_scraper.discovery.base import Candidate
+from study_scraper.topics import Topic
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_BASE_URL = "https://search.dip.bundestag.de/api/v1"
+
+# The documented shared key (DIP help page, valid into 2026 per the
+# docs at time of writing). Rotates: if live calls return 401, fetch
+# the current one from the help page or request a personal key.
+PUBLIC_API_KEY = "OSOegLs.PR2lwJ1dwCeje9vTj7FPOt3hvpYKtwKkhw"
+
+# How many topic keywords to query per run (one request chain each).
+_MAX_TERMS = 4
+
+
+def resolve_api_key(explicit: Optional[str] = None) -> str:
+    return explicit or os.environ.get("DIP_API_KEY") or PUBLIC_API_KEY
+
+
+class BundestagDIPSource:
+    """Discovery against DIP `/drucksache`."""
+
+    source_id = "bundestag_dip"
+
+    def __init__(
+        self,
+        *,
+        base_url: str = DEFAULT_BASE_URL,
+        from_file: Optional[Path] = None,
+        client: Optional[httpx.Client] = None,
+        api_key: Optional[str] = None,
+        timeout: float = 30.0,
+        user_agent: str = "study-scraper/0.0.1 (+https://github.com/cfischa/elt_data4transformation)",
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._from_file = from_file
+        self._api_key = resolve_api_key(api_key)
+        self._owns_client = client is None
+        self._client = client or httpx.Client(
+            timeout=timeout,
+            headers={"User-Agent": user_agent, "Accept": "application/json"},
+            follow_redirects=True,
+        )
+
+    def close(self) -> None:
+        if self._owns_client:
+            self._client.close()
+
+    def __enter__(self) -> "BundestagDIPSource":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Iteration
+    # ------------------------------------------------------------------
+
+    def iter_candidates(
+        self, topic: Topic, *, limit: Optional[int] = None
+    ) -> Iterator[Candidate]:
+        if self._from_file is not None:
+            payload = json.loads(self._from_file.read_text(encoding="utf-8"))
+            yielded = 0
+            for cand in self._parse_payload(payload, topic=topic):
+                yield cand
+                yielded += 1
+                if limit is not None and yielded >= limit:
+                    return
+            return
+
+        yielded = 0
+        seen_ids: set = set()
+        for term in _search_terms(topic):
+            cursor: Optional[str] = None
+            while True:
+                params: Dict[str, str] = {
+                    "apikey": self._api_key,
+                    "f.titel": term,
+                    "format": "json",
+                }
+                if cursor:
+                    params["cursor"] = cursor
+                LOGGER.info("DIP request: f.titel=%r cursor=%s", term, cursor)
+                resp = self._client.get(
+                    f"{self._base_url}/drucksache", params=params
+                )
+                resp.raise_for_status()
+                payload = resp.json()
+                got_any = False
+                for cand in self._parse_payload(payload, topic=topic):
+                    got_any = True
+                    if cand.external_id in seen_ids:
+                        continue
+                    seen_ids.add(cand.external_id)
+                    yield cand
+                    yielded += 1
+                    if limit is not None and yielded >= limit:
+                        return
+                next_cursor = payload.get("cursor")
+                # DIP signals the last page by repeating the cursor.
+                if not got_any or not next_cursor or next_cursor == cursor:
+                    break
+                cursor = next_cursor
+
+    # ------------------------------------------------------------------
+    # Parsing
+    # ------------------------------------------------------------------
+
+    def _parse_payload(
+        self, payload: Dict[str, Any], *, topic: Topic
+    ) -> Iterator[Candidate]:
+        for doc in payload.get("documents") or []:
+            cand = self._doc_to_candidate(doc, topic=topic)
+            if cand is not None:
+                yield cand
+
+    def _doc_to_candidate(
+        self, doc: Dict[str, Any], *, topic: Topic
+    ) -> Optional[Candidate]:
+        title = (doc.get("titel") or "").strip()
+        doc_id = str(doc.get("id") or "").strip()
+        if not title or not doc_id:
+            return None
+
+        fundstelle = doc.get("fundstelle") or {}
+        pdf_url = (fundstelle.get("pdf_url") or "").strip()
+        canonical_url = pdf_url or f"https://dip.bundestag.de/drucksache/{doc_id}"
+
+        urheber = [
+            u.get("titel") or u.get("bezeichnung") or ""
+            for u in (doc.get("urheber") or [])
+            if isinstance(u, dict)
+        ]
+        publisher = "; ".join(filter(None, urheber)) or "Deutscher Bundestag"
+
+        return Candidate(
+            source_id=self.source_id,
+            external_id=doc_id,
+            canonical_url=canonical_url,
+            title=title,
+            authors=[],
+            publisher=publisher,
+            publication_date=_parse_iso_date(doc.get("datum")),
+            language="de",
+            abstract=doc.get("abstract"),
+            discovery_query=topic.id,
+            raw={
+                "dip_id": doc_id,
+                "drucksachetyp": doc.get("drucksachetyp"),
+                "dokumentart": doc.get("dokumentart"),
+                "dokumentnummer": fundstelle.get("dokumentnummer"),
+                "wahlperiode": doc.get("wahlperiode"),
+                "herausgeber": fundstelle.get("herausgeber"),
+                "pdf_url": pdf_url or None,
+                "vorgangsbezug": [
+                    {"id": v.get("id"), "titel": v.get("titel"),
+                     "vorgangstyp": v.get("vorgangstyp")}
+                    for v in (doc.get("vorgangsbezug") or [])[:10]
+                    if isinstance(v, dict)
+                ],
+            },
+        )
+
+
+def _search_terms(topic: Topic) -> List[str]:
+    """Topic keywords for `f.titel`, german-locale first, deduped.
+    Synonyms lead: they are the broad umbrella terms ("Klima"), which
+    match more Drucksachen titles than narrow indicators ("CO2")."""
+    terms: List[str] = []
+    seen: set = set()
+    locales = sorted(
+        topic.locales.items(), key=lambda kv: kv[0] != "de"
+    )  # 'de' first — DIP titles are German
+    for _lang, locale in locales:
+        for term in locale.synonyms + locale.include_keywords:
+            key = term.strip().lower()
+            if not key or key in seen:
+                continue
+            seen.add(key)
+            terms.append(term.strip())
+    return terms[:_MAX_TERMS]
+
+
+def _parse_iso_date(value: Any) -> Optional[date]:
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        return None

--- a/study_scraper/dossier.py
+++ b/study_scraper/dossier.py
@@ -1,0 +1,215 @@
+"""Research dossier + evidence-gap report (product-expansion Axis 2).
+
+A dossier turns one policy question into what a researcher would
+assemble by hand: the poll-of-polls aggregate per question cluster with
+its spread, every underlying finding with year / n / population /
+institute, honest methodology notes, and a provenance appendix linking
+each cited study. Output is Markdown — citable by a journalist or NGO.
+
+The gap report is the inverse product, unique to a coverage-first
+store: per topic, which question clusters exist, how fresh and how
+broadly sourced they are — and where the holes are (stale, single
+source, no quantitative findings). It tells civil society what poll to
+commission next, and the operator which sources to wire up.
+
+Both are read-time renderers over the attribution layer; no migrations.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+from typing import Any, Dict, List, Optional
+
+from study_scraper.aggregate import aggregate_findings
+from study_scraper.clustering import cluster_attributions
+from study_scraper.findings import dedupe_attributions
+
+_STALE_YEARS = 3
+_METHOD_NOTE = (
+    "Aggregates are weighted means per question cluster: weight = "
+    "recency (3-year half-life on publication date) × sqrt(n/1000) "
+    "clamped to [0.3, 3]; undated studies are heavily discounted. "
+    "Question clustering is lexical-semantic (v1) and can over- or "
+    "under-group; every underlying finding is listed so the grouping "
+    "is checkable. Findings are machine-extracted (llm-v1) from study "
+    "text with a verbatim evidence span; extraction errors are "
+    "possible — follow the links before citing."
+)
+
+
+def _fmt_year(d: Optional[_dt.date]) -> str:
+    return str(d.year) if d else "—"
+
+
+def _fmt_n(n: Optional[float]) -> str:
+    return f"{int(n):,}" if n is not None else "—"
+
+
+def _institute(row: Dict[str, Any]) -> str:
+    return row.get("publisher") or row.get("source_id") or "—"
+
+
+def build_dossier(
+    storage: Any,
+    query: str,
+    *,
+    since: Optional[int] = None,
+    today: Optional[_dt.date] = None,
+) -> str:
+    """Render the Markdown dossier for one query. Empty result → a
+    short 'no findings' document (still valid Markdown)."""
+    today = today or _dt.date.today()
+    rows = storage.search_attributions_deduped(query=query, limit=500, since=since)
+    lines: List[str] = [f"# Research dossier: “{query}”", ""]
+    scope = f"findings from {since} onward" if since else "all ingested findings"
+    lines.append(
+        f"_Generated from the study-scraper attribution layer; {scope}._"
+    )
+    lines.append("")
+
+    if not rows:
+        lines.append("**No findings matched.** Either no ingested study answers")
+        lines.append("this question, or the attribution pass hasn't covered it")
+        lines.append("yet (`attribute` / see the evidence-gap report).")
+        return "\n".join(lines) + "\n"
+
+    answers = aggregate_findings(rows, today=today)
+
+    lines.append("## Summary — what the polls say")
+    lines.append("")
+    for a in answers:
+        lines.append(f"**{a.label}**")
+        lines.append("")
+        for p in a.positions:
+            bits = [f"{p.n_findings} poll{'s' if p.n_findings != 1 else ''}"]
+            if p.n_findings > 1:
+                bits.append(f"spread {p.min_pct:.0f}–{p.max_pct:.0f}%")
+            if p.year_min is not None:
+                bits.append(
+                    str(p.year_max) if p.year_min == p.year_max
+                    else f"{p.year_min}–{p.year_max}"
+                )
+            if p.total_sample is not None:
+                bits.append(f"Σn={p.total_sample:,}")
+            lines.append(
+                f"- {p.position}: **{p.weighted_pct:.1f}%** ({', '.join(bits)})"
+            )
+        lines.append("")
+
+    lines.append("## Findings in detail")
+    lines.append("")
+    citations: List[Dict[str, Any]] = []
+    seen_urls: set = set()
+    for a in answers:
+        lines.append(f"### {a.label}")
+        lines.append("")
+        lines.append("| % | position | year | n | population | institute / source | conf |")
+        lines.append("|---|----------|------|---|------------|--------------------|------|")
+        members = [m for p in a.positions for m in p.findings]
+        members.sort(
+            key=lambda m: (m.get("publication_date") or _dt.date.min),
+            reverse=True,
+        )
+        for m in members:
+            url = m.get("canonical_url")
+            if url and url not in seen_urls:
+                seen_urls.add(url)
+                citations.append(m)
+            ref = f"[{len(citations)}]" if url else "—"
+            conf = m.get("confidence")
+            conf_str = f"{float(conf):.2f}" if conf is not None else "—"
+            lines.append(
+                f"| {float(m['percentage']):.1f}% | {m.get('position')} "
+                f"| {_fmt_year(m.get('publication_date'))} "
+                f"| {_fmt_n(m.get('sample_size'))} "
+                f"| {m.get('population') or '—'} "
+                f"| {_institute(m)} {ref} "
+                f"| {conf_str} |"
+            )
+        lines.append("")
+
+    lines.append("## Method & caveats")
+    lines.append("")
+    lines.append(_METHOD_NOTE)
+    lines.append("")
+
+    lines.append("## Sources")
+    lines.append("")
+    for i, c in enumerate(citations, start=1):
+        title = (c.get("title") or "(untitled)").replace("\n", " ")
+        lines.append(
+            f"{i}. {title} — {_institute(c)}, "
+            f"{_fmt_year(c.get('publication_date'))}. "
+            f"<{c.get('canonical_url')}>"
+        )
+    lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def build_gap_report(
+    storage: Any,
+    *,
+    topic: Optional[str] = None,
+    today: Optional[_dt.date] = None,
+) -> str:
+    """Render the Markdown evidence-gap report for one topic (or all)."""
+    today = today or _dt.date.today()
+    topics = [topic] if topic else storage.list_distinct_attribution_topics()
+    lines: List[str] = ["# Evidence-gap report", ""]
+    lines.append(
+        "_Which questions have polling data, how fresh, how broadly "
+        "sourced — and where the holes are. A gap is a reason to find "
+        "another source or commission a poll, not a claim that no data "
+        "exists anywhere._"
+    )
+    lines.append("")
+    if not topics:
+        lines.append("**No attributed topics yet** — run the pipeline through")
+        lines.append("`attribute` first.")
+        return "\n".join(lines) + "\n"
+
+    stale_cut = today.year - _STALE_YEARS
+    for t in topics:
+        raw = storage.filter_attributions(topic=t, limit=1000)
+        rows = dedupe_attributions(raw)
+        lines.append(f"## Topic: `{t}`")
+        lines.append("")
+        if not rows:
+            lines.append("- **gap: no attributed findings at all** — studies may")
+            lines.append("  be ingested but nothing has reached the answer layer.")
+            lines.append("")
+            continue
+        clustered = cluster_attributions(rows)
+        by_cluster: Dict[int, List[Dict[str, Any]]] = {}
+        for r in clustered:
+            by_cluster.setdefault(r["cluster_id"], []).append(r)
+
+        lines.append("| question cluster | findings | institutes | latest | gaps |")
+        lines.append("|------------------|-----------|------------|--------|------|")
+        for cid, members in sorted(
+            by_cluster.items(), key=lambda kv: -len(kv[1])
+        ):
+            label = members[0]["cluster_label"]
+            institutes = {_institute(m) for m in members}
+            years = [
+                m["publication_date"].year
+                for m in members
+                if m.get("publication_date")
+            ]
+            latest = max(years) if years else None
+            with_pct = [m for m in members if m.get("percentage") is not None]
+            gaps: List[str] = []
+            if latest is None:
+                gaps.append("undated")
+            elif latest < stale_cut:
+                gaps.append(f"stale (last {latest})")
+            if len(institutes) == 1:
+                gaps.append("single source")
+            if not with_pct:
+                gaps.append("no percentages")
+            lines.append(
+                f"| {label} | {len(members)} | {len(institutes)} "
+                f"| {latest or '—'} | {', '.join(gaps) or '—'} |"
+            )
+        lines.append("")
+    return "\n".join(lines) + "\n"

--- a/study_scraper/dossier.py
+++ b/study_scraper/dossier.py
@@ -146,6 +146,85 @@ def build_dossier(
     return "\n".join(lines) + "\n"
 
 
+def build_policy_gap_report(
+    storage: Any,
+    *,
+    topic: str,
+    today: Optional[_dt.date] = None,
+) -> str:
+    """Opinion–policy gap (flagship, product Axis 4): juxtapose what
+    the polls say on a topic with what parliament is doing on it.
+
+    Opinion half: the topic's aggregated question clusters. Parliament
+    half: ingested Bundestag DIP Drucksachen on the topic, newest
+    first. v1 is a juxtaposition, not a per-question join — question →
+    bill matching needs richer DIP coverage first; the renderer makes
+    the pairing a human judgement with both halves on one page.
+    """
+    today = today or _dt.date.today()
+    lines: List[str] = [f"# Opinion–policy gap: `{topic}`", ""]
+
+    raw = storage.filter_attributions(topic=topic, limit=1000)
+    rows = dedupe_attributions(raw)
+    answers = aggregate_findings(rows, today=today)
+
+    lines.append("## What the polls say")
+    lines.append("")
+    if not answers:
+        lines.append("_(no aggregated findings for this topic yet — run the")
+        lines.append("pipeline through `attribute`)_")
+    else:
+        for a in answers[:15]:
+            lines.append(f"**{a.label}**")
+            for p in a.positions:
+                lines.append(
+                    f"- {p.position}: **{p.weighted_pct:.1f}%** "
+                    f"({p.n_findings} poll{'s' if p.n_findings != 1 else ''}"
+                    + (
+                        f", {p.year_min}–{p.year_max}"
+                        if p.year_min and p.year_min != p.year_max
+                        else (f", {p.year_max}" if p.year_max else "")
+                    )
+                    + ")"
+                )
+            lines.append("")
+
+    lines.append("## What parliament is doing")
+    lines.append("")
+    docs = storage.list_studies(
+        topic_id=topic, source_id="bundestag_dip", limit=30
+    )
+    if not docs:
+        lines.append("_(no Bundestag DIP documents ingested for this topic —")
+        lines.append("run `run --source bundestag_dip --topic " + topic + "`)_")
+    else:
+        docs.sort(
+            key=lambda d: d.get("publication_date") or _dt.date.min,
+            reverse=True,
+        )
+        for d in docs:
+            prov = d.get("provenance") or {}
+            typ = prov.get("drucksachetyp") or "Drucksache"
+            nr = prov.get("dokumentnummer")
+            nr_str = f" {nr}" if nr else ""
+            title = (d.get("title") or "").replace("\n", " ")
+            lines.append(
+                f"- **{typ}{nr_str}** ({_fmt_year(d.get('publication_date'))}, "
+                f"{d.get('publisher') or 'Deutscher Bundestag'}): {title}  "
+            )
+            lines.append(f"  <{d.get('canonical_url')}>")
+        lines.append("")
+
+    lines.append("---")
+    lines.append(
+        "_Read the two halves together: strong majorities with no "
+        "parliamentary activity, or activity against the majority, are "
+        "the gaps. Aggregation method as in the dossier; both halves "
+        "carry provenance links._"
+    )
+    return "\n".join(lines) + "\n"
+
+
 def build_gap_report(
     storage: Any,
     *,

--- a/study_scraper/dossier.py
+++ b/study_scraper/dossier.py
@@ -59,7 +59,7 @@ def build_dossier(
     """Render the Markdown dossier for one query. Empty result → a
     short 'no findings' document (still valid Markdown)."""
     today = today or _dt.date.today()
-    rows = storage.search_attributions_deduped(query=query, limit=500, since=since)
+    rows = storage.search_attributions_semantic(query=query, limit=500, since=since)
     lines: List[str] = [f"# Research dossier: “{query}”", ""]
     scope = f"findings from {since} onward" if since else "all ingested findings"
     lines.append(

--- a/study_scraper/export.py
+++ b/study_scraper/export.py
@@ -1,0 +1,85 @@
+"""Open dataset export (product-expansion Axis 3).
+
+Writes the findings layer as a versioned, reusable open dataset:
+
+    findings.csv   one row per stored attribution, with study context
+    studies.csv    metadata of every kept study (no abstracts/full text)
+    manifest.json  counts, generation time, method + legal notes
+
+Legal shape (per the product-expansion note): facts + metadata + links
+only. Toplines and provenance are facts and safe to republish;
+abstracts and full texts are NOT exported.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime as _dt
+import json
+from pathlib import Path
+from typing import Any, Dict, List
+
+FINDINGS_COLUMNS = [
+    "question", "position", "percentage", "population", "confidence",
+    "model", "sample_size", "publication_date", "publisher", "title",
+    "source_id", "canonical_url", "topic_ids",
+]
+STUDIES_COLUMNS = [
+    "id", "title", "publisher", "publication_date", "language",
+    "topic_ids", "has_quantitative_data", "source_id", "canonical_url",
+]
+
+_MANIFEST_NOTES = {
+    "method": (
+        "Findings are machine-extracted (question, position, percentage) "
+        "triples with model confidence; verify against canonical_url "
+        "before citing. Percentages are as published by the named source."
+    ),
+    "content": (
+        "Facts and metadata only: published toplines, bibliographic "
+        "fields, and links. No abstracts or full texts are included."
+    ),
+}
+
+
+def _cell(value: Any) -> Any:
+    if isinstance(value, list):
+        return "|".join(str(v) for v in value)
+    if isinstance(value, _dt.datetime):
+        return value.date().isoformat()
+    if isinstance(value, _dt.date):
+        return value.isoformat()
+    return value
+
+
+def _write_csv(path: Path, columns: List[str], rows: List[Dict[str, Any]]) -> int:
+    with path.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=columns, extrasaction="ignore")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({c: _cell(row.get(c)) for c in columns})
+    return len(rows)
+
+
+def run_export(storage: Any, out_dir: Path) -> Dict[str, Any]:
+    """Write the dataset into `out_dir`; returns the manifest dict."""
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    findings = storage.list_attributions_for_export()
+    studies = storage.list_studies_for_export()
+
+    n_findings = _write_csv(out_dir / "findings.csv", FINDINGS_COLUMNS, findings)
+    n_studies = _write_csv(out_dir / "studies.csv", STUDIES_COLUMNS, studies)
+
+    manifest = {
+        "generated_at": _dt.datetime.now(_dt.timezone.utc).isoformat(),
+        "findings": n_findings,
+        "studies": n_studies,
+        "files": ["findings.csv", "studies.csv"],
+        "notes": _MANIFEST_NOTES,
+    }
+    (out_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
+    return manifest

--- a/study_scraper/findings.py
+++ b/study_scraper/findings.py
@@ -11,12 +11,13 @@ function applied before display. No migration, fully offline-testable.
 
 A finding's identity = (normalized question, position, percentage rounded
 to the nearest whole point). Within a group we keep the highest-confidence
-row (ties broken by higher percentage, then by presence of a grounded
-source span), and report how many duplicates it stood for.
+row (ties broken by grounded source span, then newer publication date,
+then higher percentage), and report how many duplicates it stood for.
 """
 
 from __future__ import annotations
 
+import datetime as _dt
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -76,10 +77,23 @@ def _grounded(row: Dict[str, Any]) -> int:
     return 0
 
 
+def _pub_date(row: Dict[str, Any]) -> _dt.date:
+    """Publication date for recency tie-breaks; unknown sorts oldest
+    (ROADMAP item B: on confidence ties the newer poll represents the
+    finding — a 2025 topline beats a 2021 one saying the same thing)."""
+    d = row.get("publication_date")
+    if isinstance(d, _dt.datetime):
+        return d.date()
+    if isinstance(d, _dt.date):
+        return d
+    return _dt.date.min
+
+
 def dedupe_attributions(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """Collapse rows to one representative per finding key.
 
-    Representative = max by (confidence, grounded, percentage). Each kept
+    Representative = max by (confidence, grounded, publication_date,
+    percentage). Each kept
     row gains `dup_count` (how many rows shared its key, incl. itself).
     Input order of distinct findings is preserved (first appearance wins
     the slot), so an already-sorted list stays sorted.
@@ -99,8 +113,12 @@ def dedupe_attributions(rows: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
             order.append(key)
             continue
         cur = best[key]
-        challenger = (_confidence(row), _grounded(row), _percentage(row))
-        incumbent = (_confidence(cur), _grounded(cur), _percentage(cur))
+        challenger = (
+            _confidence(row), _grounded(row), _pub_date(row), _percentage(row)
+        )
+        incumbent = (
+            _confidence(cur), _grounded(cur), _pub_date(cur), _percentage(cur)
+        )
         if challenger > incumbent:
             best[key] = row
 

--- a/study_scraper/migrations/0009_watches.sql
+++ b/study_scraper/migrations/0009_watches.sql
@@ -1,0 +1,36 @@
+-- Migration 0009 — monitoring v1: standing questions ("watches") and
+-- per-digest snapshots.
+--
+-- Product-expansion note (2026-07-04), Axis 1: the scheduled crawl
+-- should produce meaning, not just rows. A watch is a standing query
+-- against the attribution layer; each `digest` run aggregates the
+-- watch's findings (poll-of-polls, ROADMAP D), compares against the
+-- previous snapshot, and reports shifts and novelties. Snapshots keep
+-- the comparison state in the DB so digests work from cron/CI.
+
+SET search_path TO study_scraper, public;
+
+CREATE TABLE IF NOT EXISTS watches (
+    id          SERIAL        PRIMARY KEY,
+    query       TEXT          NOT NULL UNIQUE,  -- keyword match against attribution questions
+    label       TEXT,                           -- human name for the digest heading
+    since_year  INT,                            -- optional recency floor (ask --since)
+    active      BOOLEAN       NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ   NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS watch_snapshots (
+    id              SERIAL       PRIMARY KEY,
+    watch_id        INT          NOT NULL REFERENCES watches(id) ON DELETE CASCADE,
+    taken_at        TIMESTAMPTZ  NOT NULL DEFAULT now(),
+    findings_count  INT          NOT NULL,
+    -- list of {cluster_label, position, weighted_pct, n_findings}
+    payload         JSONB        NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS watch_snapshots_watch_idx
+    ON watch_snapshots (watch_id, taken_at DESC);
+
+INSERT INTO schema_versions (version, description)
+    VALUES (9, 'monitoring v1: watches + watch_snapshots')
+    ON CONFLICT (version) DO NOTHING;

--- a/study_scraper/pipeline.py
+++ b/study_scraper/pipeline.py
@@ -79,8 +79,11 @@ def _candidate_to_study(
         # "already ingested" works whose canonical_url is a DOI.
         # landing_page_url / pdf_url feed the fulltext URL fallback for
         # openalex-canonical studies (fulltext.select_fetch_url).
+        # drucksachetyp / dokumentnummer / vorgangsbezug: Bundestag DIP
+        # metadata the opinion–policy gap view renders.
         for key in ("openalex_id", "referenced_works", "related_works",
-                    "landing_page_url", "pdf_url"):
+                    "landing_page_url", "pdf_url",
+                    "drucksachetyp", "dokumentnummer", "vorgangsbezug"):
             value = cand.raw.get(key)
             if value:
                 provenance_extras[key] = value

--- a/study_scraper/storage/postgres.py
+++ b/study_scraper/storage/postgres.py
@@ -1084,6 +1084,91 @@ class PostgresStorage:
                 return list(cur.fetchall())
 
     # ------------------------------------------------------------------
+    # Monitoring v1: watches + snapshots (migration 0009)
+    # ------------------------------------------------------------------
+
+    def add_watch(
+        self,
+        *,
+        query: str,
+        label: Optional[str] = None,
+        since_year: Optional[int] = None,
+    ) -> int:
+        """Register a standing question; returns the watch id.
+        Re-adding the same query re-activates it and updates label/since."""
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    INSERT INTO {SCHEMA}.watches (query, label, since_year)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (query) DO UPDATE SET
+                        label = EXCLUDED.label,
+                        since_year = EXCLUDED.since_year,
+                        active = TRUE
+                    RETURNING id
+                    """,
+                    (query, label, since_year),
+                )
+                watch_id = int(cur.fetchone()["id"])
+            conn.commit()
+        return watch_id
+
+    def list_watches(self, *, active_only: bool = True) -> List[Dict[str, Any]]:
+        where = "WHERE active" if active_only else ""
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"SELECT id, query, label, since_year, active, created_at "
+                    f"FROM {SCHEMA}.watches {where} ORDER BY id"
+                )
+                return list(cur.fetchall())
+
+    def remove_watch(self, watch_id: int) -> bool:
+        """Deactivate (not delete) so snapshot history survives."""
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"UPDATE {SCHEMA}.watches SET active = FALSE "
+                    f"WHERE id = %s AND active",
+                    (watch_id,),
+                )
+                changed = cur.rowcount > 0
+            conn.commit()
+        return changed
+
+    def latest_watch_snapshot(self, watch_id: int) -> Optional[Dict[str, Any]]:
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT id, watch_id, taken_at, findings_count, payload
+                    FROM   {SCHEMA}.watch_snapshots
+                    WHERE  watch_id = %s
+                    ORDER  BY taken_at DESC, id DESC
+                    LIMIT  1
+                    """,
+                    (watch_id,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+
+    def save_watch_snapshot(
+        self, watch_id: int, *, findings_count: int, payload: List[Dict[str, Any]]
+    ) -> None:
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    INSERT INTO {SCHEMA}.watch_snapshots
+                        (watch_id, findings_count, payload)
+                    VALUES (%s, %s, %s::jsonb)
+                    """,
+                    (watch_id, findings_count, json.dumps(payload, ensure_ascii=False)),
+                )
+            conn.commit()
+
+    # ------------------------------------------------------------------
     # Crawl runs
     # ------------------------------------------------------------------
 

--- a/study_scraper/storage/postgres.py
+++ b/study_scraper/storage/postgres.py
@@ -815,6 +815,28 @@ class PostgresStorage:
         )
         return dedupe_attributions(raw_rows)[:limit]
 
+    def search_attributions_semantic(
+        self, *, query: str, limit: int = 50, since: Optional[int] = None
+    ) -> List[Dict[str, Any]]:
+        """Deduped attribution search with a semantic fallback.
+
+        Attribution questions are normalized to English (llm-v1), so a
+        German query like 'klimaschutzgesetz' finds nothing under ILIKE.
+        When the lexical pass comes up empty, fall back to ranking ALL
+        stored findings by bilingual concept similarity (clustering.py).
+        Lexical hits keep priority — they are exact evidence."""
+        from study_scraper.clustering import semantic_filter
+
+        rows = self.search_attributions_deduped(
+            query=query, limit=limit, since=since
+        )
+        if rows:
+            return rows
+        broad = self.search_attributions_deduped(
+            query="", limit=max(limit * 10, 500), since=since
+        )
+        return semantic_filter(query, broad)[:limit]
+
     def count_attributions(self) -> int:
         with self.connection() as conn:
             with conn.cursor() as cur:

--- a/study_scraper/storage/postgres.py
+++ b/study_scraper/storage/postgres.py
@@ -1084,6 +1084,56 @@ class PostgresStorage:
                 return list(cur.fetchall())
 
     # ------------------------------------------------------------------
+    # Open dataset export
+    # ------------------------------------------------------------------
+
+    def list_attributions_for_export(self) -> List[Dict[str, Any]]:
+        """Every attribution on a non-rejected study, with study context
+        and the representative sample size — the findings.csv shape."""
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT a.question, a.position, a.percentage, a.population,
+                           a.confidence, a.model, n.sample_size,
+                           s.publication_date, s.publisher, s.title,
+                           s.source_id, s.canonical_url, s.topic_ids
+                    FROM   {SCHEMA}.attributions a
+                    JOIN   {SCHEMA}.studies s ON s.id = a.study_id
+                    LEFT JOIN LATERAL (
+                        SELECT c.numeric_value AS sample_size
+                        FROM   {SCHEMA}.claims c
+                        WHERE  c.study_id = s.id
+                          AND  c.unit = 'n'
+                          AND  c.numeric_value BETWEEN 30 AND 10000000
+                        GROUP  BY c.numeric_value
+                        ORDER  BY COUNT(*) DESC, c.numeric_value DESC
+                        LIMIT  1
+                    ) n ON TRUE
+                    WHERE  s.status <> 'rejected'
+                    ORDER  BY s.publication_date DESC NULLS LAST, a.question
+                    """
+                )
+                return list(cur.fetchall())
+
+    def list_studies_for_export(self) -> List[Dict[str, Any]]:
+        """Kept studies' bibliographic metadata — the studies.csv shape.
+        Deliberately excludes abstract / key_findings / raw artifacts."""
+        with self.connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT id, title, publisher, publication_date, language,
+                           topic_ids, has_quantitative_data, source_id,
+                           canonical_url
+                    FROM   {SCHEMA}.studies
+                    WHERE  status = 'kept'
+                    ORDER  BY publication_date DESC NULLS LAST, id
+                    """
+                )
+                return list(cur.fetchall())
+
+    # ------------------------------------------------------------------
     # Monitoring v1: watches + snapshots (migration 0009)
     # ------------------------------------------------------------------
 

--- a/study_scraper/storage/postgres.py
+++ b/study_scraper/storage/postgres.py
@@ -777,7 +777,7 @@ class PostgresStorage:
                     SELECT a.question, a.position, a.percentage, a.population,
                            a.confidence, a.model, a.raw,
                            s.title, s.canonical_url, s.source_id,
-                           s.publication_date, n.sample_size
+                           s.publisher, s.publication_date, n.sample_size
                     FROM   {SCHEMA}.attributions a
                     JOIN   {SCHEMA}.studies s ON s.id = a.study_id
                     LEFT JOIN LATERAL (
@@ -874,7 +874,7 @@ class PostgresStorage:
                     SELECT a.question, a.position, a.percentage, a.population,
                            a.confidence, a.model, a.raw,
                            s.title, s.canonical_url, s.source_id,
-                           s.publication_date, s.topic_ids
+                           s.publisher, s.publication_date, s.topic_ids
                     FROM   {SCHEMA}.attributions a
                     JOIN   {SCHEMA}.studies s ON s.id = a.study_id
                     WHERE  {where}

--- a/study_scraper/storage/postgres.py
+++ b/study_scraper/storage/postgres.py
@@ -747,9 +747,29 @@ class PostgresStorage:
         return len(rows)
 
     def search_attributions(
-        self, *, query: str, limit: int = 50
+        self, *, query: str, limit: int = 50, since: Optional[int] = None
     ) -> List[Dict[str, Any]]:
-        """ILIKE search over attribution questions; joins study context."""
+        """ILIKE search over attribution questions; joins study context.
+
+        Each row carries `sample_size` — the study's representative n=
+        claim (ROADMAP item C): the most frequent plausible sample-size
+        value extracted from that study, largest on ties. NULL when the
+        study has no n= claim.
+
+        `since` (ROADMAP item B) keeps only findings whose study was
+        published in that year or later; studies with an unknown
+        publication date are excluded when the filter is active (an
+        undatable poll can't be shown as "recent").
+        """
+        since_clause = ""
+        params: List[Any] = [f"%{query.lower()}%"]
+        if since is not None:
+            since_clause = (
+                "AND s.publication_date IS NOT NULL "
+                "AND EXTRACT(YEAR FROM s.publication_date) >= %s"
+            )
+            params.append(since)
+        params.append(limit)
         with self.connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
@@ -757,21 +777,32 @@ class PostgresStorage:
                     SELECT a.question, a.position, a.percentage, a.population,
                            a.confidence, a.model, a.raw,
                            s.title, s.canonical_url, s.source_id,
-                           s.publication_date
+                           s.publication_date, n.sample_size
                     FROM   {SCHEMA}.attributions a
                     JOIN   {SCHEMA}.studies s ON s.id = a.study_id
+                    LEFT JOIN LATERAL (
+                        SELECT c.numeric_value AS sample_size
+                        FROM   {SCHEMA}.claims c
+                        WHERE  c.study_id = s.id
+                          AND  c.unit = 'n'
+                          AND  c.numeric_value BETWEEN 30 AND 10000000
+                        GROUP  BY c.numeric_value
+                        ORDER  BY COUNT(*) DESC, c.numeric_value DESC
+                        LIMIT  1
+                    ) n ON TRUE
                     WHERE  lower(a.question) LIKE %s
                       AND  s.status <> 'rejected'
+                      {since_clause}
                     ORDER  BY a.percentage DESC NULLS LAST,
                               s.publication_date DESC NULLS LAST
                     LIMIT  %s
                     """,
-                    (f"%{query.lower()}%", limit),
+                    params,
                 )
                 return list(cur.fetchall())
 
     def search_attributions_deduped(
-        self, *, query: str, limit: int = 50
+        self, *, query: str, limit: int = 50, since: Optional[int] = None
     ) -> List[Dict[str, Any]]:
         """Like `search_attributions` but collapses the same finding seen
         across multiple studies to one confidence-weighted representative
@@ -779,7 +810,9 @@ class PostgresStorage:
         untouched. Fetches a wider window first so dedup has material."""
         from study_scraper.findings import dedupe_attributions
 
-        raw_rows = self.search_attributions(query=query, limit=max(limit * 5, 200))
+        raw_rows = self.search_attributions(
+            query=query, limit=max(limit * 5, 200), since=since
+        )
         return dedupe_attributions(raw_rows)[:limit]
 
     def count_attributions(self) -> int:

--- a/tests/study_scraper/fixtures/dip_drucksache.json
+++ b/tests/study_scraper/fixtures/dip_drucksache.json
@@ -1,0 +1,60 @@
+{
+  "numFound": 3,
+  "cursor": "AoJwgLKt0ZADLzMwMDc1NA==",
+  "documents": [
+    {
+      "id": "300754",
+      "dokumentart": "Drucksache",
+      "drucksachetyp": "Antrag",
+      "titel": "Klimaschutzgesetz konsequent umsetzen – Sektorziele wiederherstellen",
+      "datum": "2025-11-12",
+      "wahlperiode": 21,
+      "urheber": [
+        {"titel": "Fraktion BÜNDNIS 90/DIE GRÜNEN"}
+      ],
+      "fundstelle": {
+        "dokumentnummer": "21/4521",
+        "herausgeber": "BT",
+        "pdf_url": "https://dserver.bundestag.de/btd/21/045/2104521.pdf"
+      },
+      "vorgangsbezug": [
+        {"id": "320011", "titel": "Klimaschutzgesetz konsequent umsetzen", "vorgangstyp": "Antrag"}
+      ]
+    },
+    {
+      "id": "300892",
+      "dokumentart": "Drucksache",
+      "drucksachetyp": "Antwort",
+      "titel": "Antwort der Bundesregierung: Stand der Klimaanpassungsstrategie",
+      "datum": "2026-01-20",
+      "wahlperiode": 21,
+      "urheber": [
+        {"titel": "Bundesregierung"}
+      ],
+      "fundstelle": {
+        "dokumentnummer": "21/4890",
+        "herausgeber": "BT",
+        "pdf_url": "https://dserver.bundestag.de/btd/21/048/2104890.pdf"
+      },
+      "vorgangsbezug": []
+    },
+    {
+      "id": "300901",
+      "dokumentart": "Drucksache",
+      "drucksachetyp": "Gesetzentwurf",
+      "titel": "Entwurf eines Gesetzes zur Änderung des Bundes-Klimaschutzgesetzes",
+      "datum": "2026-03-05",
+      "wahlperiode": 21,
+      "urheber": [
+        {"titel": "Bundesregierung"}
+      ],
+      "fundstelle": {
+        "dokumentnummer": "21/5102",
+        "herausgeber": "BT"
+      },
+      "vorgangsbezug": [
+        {"id": "321400", "titel": "Änderung des Bundes-Klimaschutzgesetzes", "vorgangstyp": "Gesetzgebung"}
+      ]
+    }
+  ]
+}

--- a/tests/study_scraper/test_aggregate.py
+++ b/tests/study_scraper/test_aggregate.py
@@ -1,0 +1,124 @@
+"""Tests for poll-of-polls aggregation (ROADMAP D, pure; no DB)."""
+
+from __future__ import annotations
+
+import datetime
+
+from study_scraper.aggregate import (
+    aggregate_findings,
+    format_answer,
+    recency_weight,
+    sample_weight,
+)
+
+TODAY = datetime.date(2026, 7, 1)
+
+
+def _row(q, pos, pct, *, date=None, n=None, conf=0.9):
+    return {
+        "question": q, "position": pos, "percentage": pct,
+        "publication_date": date, "sample_size": n, "confidence": conf,
+    }
+
+
+class TestWeights:
+    def test_recency_half_life(self) -> None:
+        now = recency_weight(datetime.date(2026, 7, 1), TODAY)
+        three_years = recency_weight(datetime.date(2023, 7, 2), TODAY)
+        assert abs(now - 1.0) < 1e-9
+        assert abs(three_years - 0.5) < 0.01
+
+    def test_undated_is_heavily_discounted_but_not_zero(self) -> None:
+        w = recency_weight(None, TODAY)
+        assert 0.0 < w < 0.25
+
+    def test_sample_weight_reference_and_clamps(self) -> None:
+        assert sample_weight(1000) == 1.0
+        assert sample_weight(None) == 1.0
+        assert sample_weight(10) == 0.3          # clamped floor
+        assert sample_weight(10_000_000) == 3.0  # clamped ceiling
+        assert 1.9 < sample_weight(4000) < 2.1   # sqrt(4) = 2
+
+
+class TestAggregate:
+    def test_recency_pulls_weighted_mean_toward_newer_poll(self) -> None:
+        rows = [
+            _row("Stricter climate laws", "support", 44,
+                 date=datetime.date(2020, 7, 1)),
+            _row("Stricter climate laws", "support", 62,
+                 date=datetime.date(2026, 6, 1)),
+        ]
+        answers = aggregate_findings(rows, today=TODAY)
+        assert len(answers) == 1
+        agg = answers[0].get("support")
+        assert agg is not None
+        plain_mean = (44 + 62) / 2
+        assert agg.weighted_pct > plain_mean
+        assert (agg.min_pct, agg.max_pct) == (44.0, 62.0)
+        assert agg.n_findings == 2
+        assert (agg.year_min, agg.year_max) == (2020, 2026)
+
+    def test_bigger_sample_pulls_weighted_mean(self) -> None:
+        d = datetime.date(2026, 1, 1)
+        rows = [
+            _row("General speed limit", "support", 50, date=d, n=100),
+            _row("General speed limit", "support", 70, date=d, n=10_000),
+        ]
+        agg = aggregate_findings(rows, today=TODAY)[0].get("support")
+        assert agg.weighted_pct > 60
+        assert agg.total_sample == 10_100
+
+    def test_positions_kept_separate_and_ordered(self) -> None:
+        d = datetime.date(2026, 1, 1)
+        rows = [
+            _row("Re-enter nuclear energy", "oppose", 36, date=d),
+            _row("Re-enter nuclear energy", "support", 55, date=d),
+        ]
+        answer = aggregate_findings(rows, today=TODAY)[0]
+        assert [p.position for p in answer.positions] == ["support", "oppose"]
+
+    def test_de_en_variants_aggregate_into_one_cluster(self) -> None:
+        d = datetime.date(2026, 1, 1)
+        rows = [
+            _row("Return to nuclear power", "support", 55, date=d),
+            _row("Atomausstieg rückgängig machen", "support", 65, date=d),
+        ]
+        answers = aggregate_findings(rows, today=TODAY)
+        assert len(answers) == 1
+        assert answers[0].get("support").n_findings == 2
+
+    def test_rows_without_percentage_skipped(self) -> None:
+        rows = [_row("Q", "support", None)]
+        assert aggregate_findings(rows, today=TODAY) == []
+
+    def test_clusters_sorted_by_finding_count(self) -> None:
+        d = datetime.date(2026, 1, 1)
+        rows = [
+            _row("Higher pension level", "support", 70, date=d),
+            _row("General speed limit", "support", 55, date=d),
+            _row("General speed limit", "oppose", 35, date=d),
+        ]
+        answers = aggregate_findings(rows, today=TODAY)
+        assert answers[0].label == "General speed limit"
+
+
+class TestFormat:
+    def test_format_contains_spread_years_and_sigma_n(self) -> None:
+        rows = [
+            _row("Stricter climate laws", "support", 44,
+                 date=datetime.date(2022, 7, 1), n=6063),
+            _row("Stricter climate laws", "support", 62,
+                 date=datetime.date(2021, 6, 1), n=1009),
+        ]
+        text = format_answer(aggregate_findings(rows, today=TODAY)[0])
+        assert "Q: Stricter climate laws" in text
+        assert "2 polls" in text
+        assert "spread 44–62%" in text
+        assert "2021–2022" in text
+        assert "Σn=7,072" in text
+
+    def test_single_poll_omits_spread(self) -> None:
+        rows = [_row("Q", "support", 55, date=datetime.date(2025, 3, 1))]
+        text = format_answer(aggregate_findings(rows, today=TODAY)[0])
+        assert "spread" not in text
+        assert "1 poll" in text

--- a/tests/study_scraper/test_attributions.py
+++ b/tests/study_scraper/test_attributions.py
@@ -238,13 +238,15 @@ def _clean(storage) -> Iterator[None]:
     yield
 
 
-def _seed_study_with_claim(storage, *, title: str, abstract: str):
+def _seed_study_with_claim(storage, *, title: str, abstract: str,
+                           publication_date=None):
     from study_scraper.claims import extract_claims
     from study_scraper.models import Provenance, Study
     study = Study.build(
         canonical_url=f"https://example.org/{abs(hash(title))}",
         title=title,
         abstract=abstract,
+        publication_date=publication_date,
         fetched_at=datetime(2026, 6, 15, tzinfo=timezone.utc),
         source_id="openalex",
         provenance=Provenance(discovery_source="openalex"),
@@ -297,6 +299,65 @@ def test_upsert_attributions_idempotent_per_model(storage) -> None:
     apply_responses(storage=storage, responses={s.id: resp})
     apply_responses(storage=storage, responses={s.id: resp})  # re-run
     assert storage.count_attributions() == 1  # not 2
+
+
+def test_search_attributions_since_filters_old_and_undated(storage) -> None:
+    from datetime import date
+
+    from study_scraper.attribute import apply_responses
+
+    old = _seed_study_with_claim(
+        storage, title="Alt", abstract="44% befürworten strengere Klimagesetze.",
+        publication_date=date(2021, 3, 1))
+    new = _seed_study_with_claim(
+        storage, title="Neu", abstract="62% befürworten strengere Klimagesetze.",
+        publication_date=date(2025, 5, 1))
+    undated = _seed_study_with_claim(
+        storage, title="Ohne Datum",
+        abstract="50% befürworten strengere Klimagesetze.")
+
+    def resp(pct):
+        return json.dumps({"attributions": [
+            {"question": "Stricter climate laws", "position": "support",
+             "percentage": pct, "population": None, "confidence": 0.9},
+        ]})
+
+    apply_responses(storage=storage, responses={
+        old.id: resp(44), new.id: resp(62), undated.id: resp(50)})
+
+    all_hits = storage.search_attributions(query="climate")
+    assert len(all_hits) == 3
+    recent = storage.search_attributions(query="climate", since=2024)
+    assert [float(r["percentage"]) for r in recent] == [62.0]
+
+
+def test_search_attributions_carries_sample_size(storage) -> None:
+    from study_scraper.attribute import apply_responses
+
+    s = _seed_study_with_claim(
+        storage, title="Tempolimit",
+        abstract="60% der Befragten (n=1009) befürworten ein Tempolimit.")
+    resp = json.dumps({"attributions": [
+        {"question": "General speed limit", "position": "support",
+         "percentage": 60, "population": None, "confidence": 0.9},
+    ]})
+    apply_responses(storage=storage, responses={s.id: resp})
+    hits = storage.search_attributions(query="speed limit")
+    assert hits and int(hits[0]["sample_size"]) == 1009
+
+
+def test_search_attributions_sample_size_null_without_n_claim(storage) -> None:
+    from study_scraper.attribute import apply_responses
+
+    s = _seed_study_with_claim(
+        storage, title="Rente", abstract="70% wollen ein höheres Rentenniveau.")
+    resp = json.dumps({"attributions": [
+        {"question": "Higher pension level", "position": "support",
+         "percentage": 70, "population": None, "confidence": 0.9},
+    ]})
+    apply_responses(storage=storage, responses={s.id: resp})
+    hits = storage.search_attributions(query="pension")
+    assert hits and hits[0]["sample_size"] is None
 
 
 def test_dump_prompts_emits_queue(storage) -> None:

--- a/tests/study_scraper/test_audit_cli.py
+++ b/tests/study_scraper/test_audit_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from typing import Iterator
 
 import pytest
@@ -14,12 +15,19 @@ from study_scraper.cli import app
 TEST_DSN = os.environ.get("STUDY_SCRAPER_TEST_DSN")
 
 
+def _plain(text: str) -> str:
+    """Strip ANSI escapes: on CI runners rich forces terminal mode and
+    styles help output, splitting option names with color codes (seen
+    with rich 15 on GitHub Actions, 2026-07-05)."""
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
 def test_cli_registers_audit_command() -> None:
     runner = CliRunner()
     result = runner.invoke(app, ["audit", "--help"])
     assert result.exit_code == 0
-    assert "--sample-size" in result.output
-    assert "spot-check" in result.output.lower()
+    assert "--sample-size" in _plain(result.output)
+    assert "spot-check" in _plain(result.output).lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/study_scraper/test_bundestag_dip.py
+++ b/tests/study_scraper/test_bundestag_dip.py
@@ -1,0 +1,83 @@
+"""Tests for the Bundestag DIP discovery source.
+
+The from_file fixture and the live HTTP path share the same parser, so
+testing the fixture path validates production parsing.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from study_scraper.discovery.bundestag_dip import (
+    PUBLIC_API_KEY,
+    BundestagDIPSource,
+    _search_terms,
+    resolve_api_key,
+)
+from study_scraper.topics import load_topics
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "dip_drucksache.json"
+
+
+@pytest.fixture(scope="module")
+def klima():
+    topics = load_topics(
+        Path(__file__).resolve().parents[2] / "config" / "topics" / "topics.csv"
+    )
+    return next(t for t in topics if t.id == "klima")
+
+
+class TestFromFile:
+    def test_parses_all_documents(self, klima) -> None:
+        with BundestagDIPSource(from_file=FIXTURE) as src:
+            cands = list(src.iter_candidates(klima))
+        assert len(cands) == 3
+        assert all(c.source_id == "bundestag_dip" for c in cands)
+
+    def test_candidate_fields(self, klima) -> None:
+        with BundestagDIPSource(from_file=FIXTURE) as src:
+            cand = next(src.iter_candidates(klima))
+        assert cand.external_id == "300754"
+        assert cand.title.startswith("Klimaschutzgesetz konsequent umsetzen")
+        assert cand.canonical_url == (
+            "https://dserver.bundestag.de/btd/21/045/2104521.pdf"
+        )
+        assert cand.publisher == "Fraktion BÜNDNIS 90/DIE GRÜNEN"
+        assert cand.publication_date == date(2025, 11, 12)
+        assert cand.language == "de"
+        assert cand.raw["drucksachetyp"] == "Antrag"
+        assert cand.raw["dokumentnummer"] == "21/4521"
+        assert cand.raw["vorgangsbezug"][0]["vorgangstyp"] == "Antrag"
+
+    def test_missing_pdf_falls_back_to_dip_page(self, klima) -> None:
+        with BundestagDIPSource(from_file=FIXTURE) as src:
+            cands = list(src.iter_candidates(klima))
+        gesetzentwurf = next(c for c in cands if c.external_id == "300901")
+        assert gesetzentwurf.canonical_url == (
+            "https://dip.bundestag.de/drucksache/300901"
+        )
+
+    def test_limit_respected(self, klima) -> None:
+        with BundestagDIPSource(from_file=FIXTURE) as src:
+            cands = list(src.iter_candidates(klima, limit=1))
+        assert len(cands) == 1
+
+
+class TestSearchTerms:
+    def test_german_terms_first_and_capped(self, klima) -> None:
+        terms = _search_terms(klima)
+        assert 0 < len(terms) <= 4
+        # klima topic's German vocabulary should lead.
+        assert any("klima" in t.lower() for t in terms)
+
+
+class TestApiKey:
+    def test_resolution_order(self, monkeypatch) -> None:
+        monkeypatch.delenv("DIP_API_KEY", raising=False)
+        assert resolve_api_key() == PUBLIC_API_KEY
+        monkeypatch.setenv("DIP_API_KEY", "personal-key")
+        assert resolve_api_key() == "personal-key"
+        assert resolve_api_key("explicit") == "explicit"

--- a/tests/study_scraper/test_clustering.py
+++ b/tests/study_scraper/test_clustering.py
@@ -1,0 +1,94 @@
+"""Tests for semantic question clustering (ROADMAP E, pure; no DB)."""
+
+from __future__ import annotations
+
+from study_scraper.clustering import (
+    DEFAULT_THRESHOLD,
+    cluster_attributions,
+    cluster_questions,
+    question_similarity,
+)
+
+
+class TestSimilarity:
+    def test_roadmap_example_de_en_nuclear(self) -> None:
+        # The literal ROADMAP item E example.
+        sim = question_similarity(
+            "Atomausstieg rückgängig machen", "Return to nuclear power"
+        )
+        assert sim >= DEFAULT_THRESHOLD
+
+    def test_same_topic_different_question_stays_apart(self) -> None:
+        # Both climate — but 'stricter laws' and 'EU priority' are
+        # different survey questions and must NOT merge.
+        sim = question_similarity(
+            "Stricter climate laws", "EU climate priority"
+        )
+        assert sim < DEFAULT_THRESHOLD
+
+    def test_plural_and_phrasing_variants_cluster(self) -> None:
+        sim = question_similarity(
+            "Stricter climate laws", "Germany should tighten its climate law"
+        )
+        assert sim >= DEFAULT_THRESHOLD
+
+    def test_umlaut_folding(self) -> None:
+        assert question_similarity("Rückkehr zur Atomkraft", "ruckkehr zur atomkraft") == 1.0
+
+    def test_unrelated_questions_zero(self) -> None:
+        sim = question_similarity(
+            "Higher pension level", "General speed limit on the Autobahn"
+        )
+        assert sim < 0.2
+
+    def test_empty_question_no_crash(self) -> None:
+        assert question_similarity("", "anything") == 0.0
+
+
+class TestClusterQuestions:
+    def test_deterministic_ids_in_first_appearance_order(self) -> None:
+        qs = [
+            "Return to nuclear power",
+            "Stricter climate laws",
+            "Atomausstieg rückgängig machen",   # joins cluster 0
+            "Tighten the climate law",           # joins cluster 1
+        ]
+        assert cluster_questions(qs) == [0, 1, 0, 1]
+
+    def test_singletons_get_own_cluster(self) -> None:
+        qs = ["A pension question", "A housing question", "A defense question"]
+        assert cluster_questions(qs) == [0, 1, 2]
+
+    def test_empty_input(self) -> None:
+        assert cluster_questions([]) == []
+
+    def test_custom_embedder_backend(self) -> None:
+        # Dense-vector path: everything identical → one cluster.
+        def embedder(texts):
+            return [[1.0, 0.0] for _ in texts]
+
+        assert cluster_questions(["a", "b", "c"], embedder=embedder) == [0, 0, 0]
+
+
+class TestClusterAttributions:
+    def test_annotates_rows_with_cluster_and_label(self) -> None:
+        rows = [
+            {"question": "Return to nuclear power", "percentage": 55},
+            {"question": "Atomausstieg rückgängig machen", "percentage": 61},
+            {"question": "Return to nuclear power", "percentage": 65},
+        ]
+        out = cluster_attributions(rows)
+        assert [r["cluster_id"] for r in out] == [0, 0, 0]
+        # Most common phrasing wins the label.
+        assert out[0]["cluster_label"] == "Return to nuclear power"
+        # Raw rows not mutated.
+        assert "cluster_id" not in rows[0]
+
+    def test_label_tie_prefers_shortest(self) -> None:
+        rows = [
+            {"question": "Tighten the existing climate law"},
+            {"question": "Stricter climate laws"},
+        ]
+        out = cluster_attributions(rows)
+        assert out[0]["cluster_id"] == out[1]["cluster_id"]
+        assert out[0]["cluster_label"] == "Stricter climate laws"

--- a/tests/study_scraper/test_clustering.py
+++ b/tests/study_scraper/test_clustering.py
@@ -7,6 +7,7 @@ from study_scraper.clustering import (
     cluster_attributions,
     cluster_questions,
     question_similarity,
+    semantic_filter,
 )
 
 
@@ -33,7 +34,8 @@ class TestSimilarity:
         assert sim >= DEFAULT_THRESHOLD
 
     def test_umlaut_folding(self) -> None:
-        assert question_similarity("Rückkehr zur Atomkraft", "ruckkehr zur atomkraft") == 1.0
+        sim = question_similarity("Rückkehr zur Atomkraft", "ruckkehr zur atomkraft")
+        assert abs(sim - 1.0) < 1e-9
 
     def test_unrelated_questions_zero(self) -> None:
         sim = question_similarity(
@@ -43,6 +45,60 @@ class TestSimilarity:
 
     def test_empty_question_no_crash(self) -> None:
         assert question_similarity("", "anything") == 0.0
+
+
+class TestOverMergeRegressions:
+    def test_build_new_plants_distinct_from_general_use(self) -> None:
+        # Real-data regression (2026-07-05): 32% (build new plants) and
+        # 65% (use nuclear power) merged into a meaningless 48.5%.
+        sim = question_similarity(
+            "Use nuclear power", "Build new nuclear power plants"
+        )
+        assert sim < DEFAULT_THRESHOLD
+
+    def test_kraftwerk_maps_to_plant_cross_language(self) -> None:
+        sim = question_similarity(
+            "Neubau neuer Kernkraftwerke", "Build new nuclear power plants"
+        )
+        assert sim >= DEFAULT_THRESHOLD
+
+    def test_distinct_climate_questions_stay_apart(self) -> None:
+        # Real-data regression (2026-07-05): at concept weight 3, nine
+        # different climate questions merged into one mushy cluster.
+        pairs = [
+            ("Ambitious climate protection policy",
+             "Climate protection is an important political task"),
+            ("Ambitious climate protection policy",
+             "Politics must implement more climate protection measures"),
+            ("Willingness to reduce household energy consumption",
+             "Ambitious climate protection policy"),
+        ]
+        for a, b in pairs:
+            assert question_similarity(a, b) < DEFAULT_THRESHOLD, (a, b)
+
+
+class TestSemanticFilter:
+    def test_german_query_finds_english_questions(self) -> None:
+        # `ask klimaschutzgesetz` returned nothing under ILIKE because
+        # llm-v1 normalizes questions to English (found 2026-07-05).
+        rows = [
+            {"question": "Stricter climate protection laws", "percentage": 44},
+            {"question": "Higher pension level", "percentage": 70},
+        ]
+        out = semantic_filter("klimaschutzgesetz", rows)
+        assert [r["question"] for r in out] == ["Stricter climate protection laws"]
+
+    def test_ranked_best_first(self) -> None:
+        rows = [
+            {"question": "Ambitious climate protection policy"},
+            {"question": "Stricter climate protection laws"},
+        ]
+        out = semantic_filter("klimagesetz", rows)
+        assert out[0]["question"] == "Stricter climate protection laws"
+
+    def test_unrelated_rows_dropped(self) -> None:
+        rows = [{"question": "General speed limit"}]
+        assert semantic_filter("klimaschutzgesetz", rows) == []
 
 
 class TestClusterQuestions:

--- a/tests/study_scraper/test_digest.py
+++ b/tests/study_scraper/test_digest.py
@@ -44,7 +44,7 @@ class FakeStorage:
     def list_watches(self, *, active_only: bool = True):
         return [w for w in self.watches if w["active"] or not active_only]
 
-    def search_attributions_deduped(self, *, query: str, limit: int = 500,
+    def search_attributions_semantic(self, *, query: str, limit: int = 500,
                                     since: Optional[int] = None):
         rows = [f for f in self.findings if query.lower() in f["question"].lower()]
         if since is not None:

--- a/tests/study_scraper/test_digest.py
+++ b/tests/study_scraper/test_digest.py
@@ -1,0 +1,192 @@
+"""Tests for monitoring v1: watches storage + the digest engine.
+
+Digest-engine tests run against a fake in-memory storage (pure);
+watch-table round-trip tests gate on STUDY_SCRAPER_TEST_DSN.
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from study_scraper.digest import (
+    SHIFT_POINTS,
+    digest_watch,
+    format_digest_markdown,
+    run_digest,
+)
+
+TODAY = datetime.date(2026, 7, 1)
+
+
+def _finding(q, pos, pct, *, date=None, n=None):
+    return {
+        "question": q, "position": pos, "percentage": pct,
+        "publication_date": date or datetime.date(2026, 1, 1),
+        "sample_size": n, "confidence": 0.9,
+    }
+
+
+class FakeStorage:
+    """In-memory stand-in exposing the digest engine's storage surface."""
+
+    def __init__(self, findings: List[Dict[str, Any]]) -> None:
+        self.findings = findings
+        self.snapshots: Dict[int, List[Dict[str, Any]]] = {}
+        self.watches: List[Dict[str, Any]] = [
+            {"id": 1, "query": "", "label": "Everything", "since_year": None,
+             "active": True}
+        ]
+
+    def list_watches(self, *, active_only: bool = True):
+        return [w for w in self.watches if w["active"] or not active_only]
+
+    def search_attributions_deduped(self, *, query: str, limit: int = 500,
+                                    since: Optional[int] = None):
+        rows = [f for f in self.findings if query.lower() in f["question"].lower()]
+        if since is not None:
+            rows = [r for r in rows
+                    if r.get("publication_date")
+                    and r["publication_date"].year >= since]
+        return rows[:limit]
+
+    def latest_watch_snapshot(self, watch_id: int):
+        snaps = self.snapshots.get(watch_id) or []
+        return snaps[-1] if snaps else None
+
+    def save_watch_snapshot(self, watch_id: int, *, findings_count: int,
+                            payload: List[Dict[str, Any]]):
+        self.snapshots.setdefault(watch_id, []).append(
+            {"watch_id": watch_id, "findings_count": findings_count,
+             "payload": payload}
+        )
+
+
+def test_first_run_stores_baseline_and_reports_no_shift() -> None:
+    store = FakeStorage([_finding("Stricter climate laws", "support", 62)])
+    [d] = run_digest(store, today=TODAY)
+    assert d.first_run and not d.shifts and not d.new_questions
+    assert store.snapshots[1][0]["findings_count"] == 1
+
+
+def test_shift_detected_above_threshold(_pct_from=55.0, _pct_to=61.0) -> None:
+    store = FakeStorage([_finding("Return to nuclear power", "support", _pct_from)])
+    run_digest(store, today=TODAY)
+    # New poll replaces the old one → weighted pct moves.
+    store.findings = [_finding("Return to nuclear power", "support", _pct_to)]
+    [d] = run_digest(store, today=TODAY)
+    assert len(d.shifts) == 1
+    s = d.shifts[0]
+    assert s["from_pct"] == _pct_from and s["to_pct"] == _pct_to
+    assert abs(s["delta"]) >= SHIFT_POINTS
+
+
+def test_small_movement_not_reported() -> None:
+    store = FakeStorage([_finding("Q about pension", "support", 70)])
+    run_digest(store, today=TODAY)
+    store.findings = [_finding("Q about pension", "support", 72)]
+    [d] = run_digest(store, today=TODAY)
+    assert d.shifts == []
+
+
+def test_shift_matches_cluster_across_phrasing_drift() -> None:
+    # Label drift: the DE phrasing wins the label in run 2, but the
+    # cluster must still match run 1's snapshot fuzzily.
+    store = FakeStorage([_finding("Return to nuclear power", "support", 55)])
+    run_digest(store, today=TODAY)
+    store.findings = [
+        _finding("Atomausstieg rückgängig machen", "support", 65),
+        _finding("Atomausstieg rückgängig machen", "support", 65),
+    ]
+    [d] = run_digest(store, today=TODAY)
+    assert len(d.shifts) == 1
+    assert d.shifts[0]["delta"] == 10.0
+
+
+def test_new_question_reported_after_baseline() -> None:
+    store = FakeStorage([_finding("Stricter climate laws", "support", 62)])
+    run_digest(store, today=TODAY)
+    store.findings.append(_finding("General speed limit", "support", 57))
+    [d] = run_digest(store, today=TODAY)
+    assert d.new_questions == ["General speed limit"]
+
+
+def test_watch_since_year_filters_findings() -> None:
+    store = FakeStorage([
+        _finding("Old poll question", "support", 40,
+                 date=datetime.date(2019, 1, 1)),
+        _finding("Old poll question", "support", 60,
+                 date=datetime.date(2026, 1, 1)),
+    ])
+    store.watches[0]["since_year"] = 2024
+    [d] = run_digest(store, today=TODAY)
+    assert d.findings_count == 1
+
+
+def test_dry_run_saves_nothing() -> None:
+    store = FakeStorage([_finding("Q", "support", 50)])
+    run_digest(store, today=TODAY, save=False)
+    assert store.snapshots == {}
+
+
+def test_markdown_contains_shift_and_method() -> None:
+    store = FakeStorage([_finding("Return to nuclear power", "support", 55)])
+    run_digest(store, today=TODAY)
+    store.findings = [_finding("Return to nuclear power", "support", 65)]
+    digests = run_digest(store, today=TODAY)
+    md = format_digest_markdown(
+        digests,
+        generated_at=datetime.datetime(2026, 7, 1, tzinfo=datetime.timezone.utc),
+    )
+    assert "# Opinion digest — 2026-07-01" in md
+    assert "▲ shift" in md and "55.0% → 65.0%" in md
+    assert "Method: weighted mean" in md
+
+
+def test_markdown_no_watches() -> None:
+    md = format_digest_markdown([])
+    assert "No active watches" in md
+
+
+# ---------------------------------------------------------------------------
+# Integration: watches table round-trip
+# ---------------------------------------------------------------------------
+
+TEST_DSN = os.environ.get("STUDY_SCRAPER_TEST_DSN")
+
+
+@pytest.mark.skipif(not TEST_DSN, reason="STUDY_SCRAPER_TEST_DSN not set")
+def test_watch_roundtrip_and_snapshot() -> None:
+    from study_scraper.storage import PostgresStorage
+
+    store = PostgresStorage(TEST_DSN)
+    store.migrate()
+    with store.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE study_scraper.watch_snapshots, study_scraper.watches")
+        conn.commit()
+
+    wid = store.add_watch(query="klima", label="Climate", since_year=2024)
+    assert store.list_watches()[0]["query"] == "klima"
+
+    # Re-add updates in place (same id), no duplicate.
+    wid2 = store.add_watch(query="klima", label="Klima", since_year=None)
+    assert wid2 == wid
+    assert len(store.list_watches()) == 1
+    assert store.list_watches()[0]["label"] == "Klima"
+
+    assert store.latest_watch_snapshot(wid) is None
+    store.save_watch_snapshot(wid, findings_count=3, payload=[
+        {"cluster_label": "Q", "position": "support",
+         "weighted_pct": 60.0, "n_findings": 3},
+    ])
+    snap = store.latest_watch_snapshot(wid)
+    assert snap["findings_count"] == 3
+    assert snap["payload"][0]["weighted_pct"] == 60.0
+
+    assert store.remove_watch(wid) is True
+    assert store.list_watches() == []
+    assert len(store.list_watches(active_only=False)) == 1

--- a/tests/study_scraper/test_dossier.py
+++ b/tests/study_scraper/test_dossier.py
@@ -35,7 +35,7 @@ class FakeStorage:
         assert source_id == "bundestag_dip"
         return list(self.dip_docs)
 
-    def search_attributions_deduped(self, *, query: str, limit: int = 500,
+    def search_attributions_semantic(self, *, query: str, limit: int = 500,
                                     since: Optional[int] = None):
         rows = [f for f in self.findings if query.lower() in f["question"].lower()]
         if since is not None:

--- a/tests/study_scraper/test_dossier.py
+++ b/tests/study_scraper/test_dossier.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import datetime
 from typing import Any, Dict, List, Optional
 
-from study_scraper.dossier import build_dossier, build_gap_report
+from study_scraper.dossier import (
+    build_dossier,
+    build_gap_report,
+    build_policy_gap_report,
+)
 
 TODAY = datetime.date(2026, 7, 1)
 
@@ -21,8 +25,15 @@ def _finding(q, pos, pct, *, date=None, n=None, publisher="Forsa",
 
 
 class FakeStorage:
-    def __init__(self, findings: List[Dict[str, Any]]) -> None:
+    def __init__(self, findings: List[Dict[str, Any]],
+                 dip_docs: Optional[List[Dict[str, Any]]] = None) -> None:
         self.findings = findings
+        self.dip_docs = dip_docs or []
+
+    def list_studies(self, *, topic_id=None, source_id=None, status="kept",
+                     limit=100):
+        assert source_id == "bundestag_dip"
+        return list(self.dip_docs)
 
     def search_attributions_deduped(self, *, query: str, limit: int = 500,
                                     since: Optional[int] = None):
@@ -126,3 +137,36 @@ class TestGapReport:
         ])
         md = build_gap_report(store, today=TODAY)
         assert "## Topic: `klima`" in md and "## Topic: `rente`" in md
+
+
+class TestPolicyGap:
+    def _dip_doc(self, title, *, typ="Antrag", nr="21/4521",
+                 date_=datetime.date(2025, 11, 12)):
+        return {
+            "title": title, "publisher": "Fraktion X",
+            "publication_date": date_,
+            "canonical_url": "https://dserver.bundestag.de/btd/x.pdf",
+            "provenance": {"drucksachetyp": typ, "dokumentnummer": nr},
+        }
+
+    def test_juxtaposes_opinion_and_parliament(self) -> None:
+        store = FakeStorage(
+            [_finding("Stricter climate laws", "support", 62,
+                      date=datetime.date(2025, 6, 1))],
+            dip_docs=[self._dip_doc("Klimaschutzgesetz konsequent umsetzen")],
+        )
+        md = build_policy_gap_report(store, topic="klima", today=TODAY)
+        assert "# Opinion–policy gap: `klima`" in md
+        assert "## What the polls say" in md
+        assert "support: **62.0%**" in md
+        assert "## What parliament is doing" in md
+        assert "**Antrag 21/4521** (2025, Fraktion X)" in md
+        assert "dserver.bundestag.de" in md
+
+    def test_empty_halves_have_hints(self) -> None:
+        md = build_policy_gap_report(
+            FakeStorage([], dip_docs=[]), topic="rente", today=TODAY
+        )
+        assert "no aggregated findings" in md
+        assert "no Bundestag DIP documents" in md
+        assert "run `run --source bundestag_dip --topic rente`" in md

--- a/tests/study_scraper/test_dossier.py
+++ b/tests/study_scraper/test_dossier.py
@@ -1,0 +1,128 @@
+"""Tests for the research dossier + evidence-gap report (pure; no DB)."""
+
+from __future__ import annotations
+
+import datetime
+from typing import Any, Dict, List, Optional
+
+from study_scraper.dossier import build_dossier, build_gap_report
+
+TODAY = datetime.date(2026, 7, 1)
+
+
+def _finding(q, pos, pct, *, date=None, n=None, publisher="Forsa",
+             url="https://example.org/a", title="Study A", topic="klima"):
+    return {
+        "question": q, "position": pos, "percentage": pct,
+        "publication_date": date, "sample_size": n, "confidence": 0.9,
+        "publisher": publisher, "canonical_url": url, "title": title,
+        "source_id": "openalex", "topic_ids": [topic], "raw": {},
+    }
+
+
+class FakeStorage:
+    def __init__(self, findings: List[Dict[str, Any]]) -> None:
+        self.findings = findings
+
+    def search_attributions_deduped(self, *, query: str, limit: int = 500,
+                                    since: Optional[int] = None):
+        rows = [f for f in self.findings if query.lower() in f["question"].lower()]
+        if since is not None:
+            rows = [r for r in rows
+                    if r.get("publication_date")
+                    and r["publication_date"].year >= since]
+        return rows[:limit]
+
+    def filter_attributions(self, *, topic=None, limit=1000, **kw):
+        return [f for f in self.findings if topic in (f.get("topic_ids") or [])]
+
+    def list_distinct_attribution_topics(self):
+        out = sorted({t for f in self.findings for t in f.get("topic_ids") or []})
+        return out
+
+
+class TestDossier:
+    def test_full_dossier_structure(self) -> None:
+        store = FakeStorage([
+            _finding("Stricter climate laws", "support", 62,
+                     date=datetime.date(2021, 6, 1), n=1009,
+                     publisher="Forsa", url="https://example.org/forsa",
+                     title="Forsa Klima"),
+            _finding("Stricter climate laws", "support", 44,
+                     date=datetime.date(2022, 3, 1), n=6063,
+                     publisher="Ariadne", url="https://example.org/ariadne",
+                     title="Ariadne Panel"),
+        ])
+        md = build_dossier(store, "climate", today=TODAY)
+        assert "# Research dossier: “climate”" in md
+        assert "## Summary — what the polls say" in md
+        assert "2 polls" in md and "spread 44–62%" in md
+        assert "## Findings in detail" in md
+        assert "| 44.0% | support | 2022 | 6,063 |" in md
+        assert "## Method & caveats" in md
+        assert "## Sources" in md
+        assert "<https://example.org/forsa>" in md
+        # newest-first in the detail table
+        assert md.index("44.0%") < md.index("62.0%")
+
+    def test_empty_dossier_says_so(self) -> None:
+        md = build_dossier(FakeStorage([]), "nothing", today=TODAY)
+        assert "No findings matched" in md
+
+    def test_since_filter_propagates(self) -> None:
+        store = FakeStorage([
+            _finding("Stricter climate laws", "support", 44,
+                     date=datetime.date(2020, 1, 1)),
+        ])
+        md = build_dossier(store, "climate", since=2024, today=TODAY)
+        assert "No findings matched" in md
+
+    def test_citation_dedup_across_findings(self) -> None:
+        # Two findings from the SAME study → one Sources entry.
+        store = FakeStorage([
+            _finding("Re-enter nuclear energy", "support", 55,
+                     date=datetime.date(2025, 3, 1)),
+            _finding("Re-enter nuclear energy", "oppose", 36,
+                     date=datetime.date(2025, 3, 1)),
+        ])
+        md = build_dossier(store, "nuclear", today=TODAY)
+        assert md.count("<https://example.org/a>") == 1
+
+
+class TestGapReport:
+    def test_flags_stale_and_single_source(self) -> None:
+        store = FakeStorage([
+            _finding("Old lonely question", "support", 50,
+                     date=datetime.date(2020, 1, 1)),
+        ])
+        md = build_gap_report(store, topic="klima", today=TODAY)
+        assert "## Topic: `klima`" in md
+        assert "stale (last 2020)" in md
+        assert "single source" in md
+
+    def test_fresh_multi_source_cluster_has_no_gaps(self) -> None:
+        store = FakeStorage([
+            _finding("Stricter climate laws", "support", 62,
+                     date=datetime.date(2026, 1, 1), publisher="Forsa",
+                     url="https://example.org/1"),
+            _finding("Stricter climate laws", "support", 58,
+                     date=datetime.date(2025, 6, 1), publisher="Civey",
+                     url="https://example.org/2"),
+        ])
+        md = build_gap_report(store, topic="klima", today=TODAY)
+        row = next(l for l in md.splitlines() if "Stricter climate laws" in l)
+        assert row.rstrip().endswith("| — |")
+
+    def test_topic_without_findings_is_a_gap(self) -> None:
+        md = build_gap_report(FakeStorage([]), topic="rente", today=TODAY)
+        assert "no attributed findings at all" in md
+
+    def test_all_topics_mode_lists_each(self) -> None:
+        store = FakeStorage([
+            _finding("Q1 about climate", "support", 60, topic="klima",
+                     date=datetime.date(2026, 1, 1)),
+            _finding("Q2 about pension", "support", 70, topic="rente",
+                     date=datetime.date(2026, 1, 1)),
+        ])
+        md = build_gap_report(store, today=TODAY)
+        assert "## Topic: `klima`" in md and "## Topic: `rente`" in md

--- a/tests/study_scraper/test_export.py
+++ b/tests/study_scraper/test_export.py
@@ -1,0 +1,71 @@
+"""Tests for the open dataset export (pure via fake storage + one DB test)."""
+
+from __future__ import annotations
+
+import csv
+import datetime
+import json
+import os
+
+import pytest
+
+from study_scraper.export import run_export
+
+
+class FakeStorage:
+    def list_attributions_for_export(self):
+        return [
+            {"question": "Stricter climate laws", "position": "support",
+             "percentage": 62.0, "population": None, "confidence": 0.9,
+             "model": "llm-v1", "sample_size": 1009,
+             "publication_date": datetime.date(2021, 6, 1),
+             "publisher": "Forsa", "title": "Klima-Umfrage",
+             "source_id": "openalex",
+             "canonical_url": "https://example.org/a",
+             "topic_ids": ["klima", "energie"]},
+        ]
+
+    def list_studies_for_export(self):
+        return [
+            {"id": "a" * 64, "title": "Klima-Umfrage", "publisher": "Forsa",
+             "publication_date": datetime.date(2021, 6, 1), "language": "de",
+             "topic_ids": ["klima"], "has_quantitative_data": True,
+             "source_id": "openalex",
+             "canonical_url": "https://example.org/a"},
+        ]
+
+
+def test_export_writes_csvs_and_manifest(tmp_path) -> None:
+    manifest = run_export(FakeStorage(), tmp_path / "ds")
+
+    assert manifest["findings"] == 1 and manifest["studies"] == 1
+    on_disk = json.loads((tmp_path / "ds" / "manifest.json").read_text())
+    assert on_disk["files"] == ["findings.csv", "studies.csv"]
+    assert "notes" in on_disk
+
+    with (tmp_path / "ds" / "findings.csv").open() as fh:
+        rows = list(csv.DictReader(fh))
+    assert rows[0]["question"] == "Stricter climate laws"
+    assert rows[0]["percentage"] == "62.0"
+    assert rows[0]["publication_date"] == "2021-06-01"
+    assert rows[0]["topic_ids"] == "klima|energie"   # list flattening
+
+    with (tmp_path / "ds" / "studies.csv").open() as fh:
+        srows = list(csv.DictReader(fh))
+    assert srows[0]["canonical_url"] == "https://example.org/a"
+    # Legal shape: no abstract column anywhere.
+    assert "abstract" not in srows[0] and "abstract" not in rows[0]
+
+
+TEST_DSN = os.environ.get("STUDY_SCRAPER_TEST_DSN")
+
+
+@pytest.mark.skipif(not TEST_DSN, reason="STUDY_SCRAPER_TEST_DSN not set")
+def test_export_storage_queries_run(tmp_path) -> None:
+    from study_scraper.storage import PostgresStorage
+
+    store = PostgresStorage(TEST_DSN)
+    store.migrate()
+    manifest = run_export(store, tmp_path / "ds")
+    assert (tmp_path / "ds" / "findings.csv").exists()
+    assert manifest["findings"] >= 0

--- a/tests/study_scraper/test_findings_dedup.py
+++ b/tests/study_scraper/test_findings_dedup.py
@@ -72,6 +72,35 @@ def test_dedupe_grounded_breaks_confidence_tie() -> None:
     assert out[0]["raw"]["grounded"] is True
 
 
+def test_dedupe_newer_publication_breaks_confidence_tie() -> None:
+    # ROADMAP item B: on equal confidence + groundedness, the newer
+    # study's row represents the finding.
+    import datetime
+
+    rows = [
+        {**_row("Q", "support", 50, 0.8), "title": "old",
+         "publication_date": datetime.date(2021, 1, 1)},
+        {**_row("Q", "support", 50, 0.8), "title": "new",
+         "publication_date": datetime.date(2025, 6, 1)},
+    ]
+    out = dedupe_attributions(rows)
+    assert len(out) == 1
+    assert out[0]["title"] == "new"
+
+
+def test_dedupe_unknown_date_loses_to_dated_row() -> None:
+    import datetime
+
+    rows = [
+        {**_row("Q", "support", 50, 0.8), "title": "dated",
+         "publication_date": datetime.date(2020, 1, 1)},
+        {**_row("Q", "support", 50, 0.8), "title": "undated",
+         "publication_date": None},
+    ]
+    out = dedupe_attributions(rows)
+    assert out[0]["title"] == "dated"
+
+
 def test_empty_input() -> None:
     assert dedupe_attributions([]) == []
 


### PR DESCRIPTION
## What

Implements the product-expansion strategy (first commit adds the strategy note itself, `docs/study_scraper/notes/product-expansion-2026-07-04.md`; the rest builds everything from it that is buildable today). **392 tests pass** (was 330 at baseline); the full loop was verified end-to-end against a real Postgres.

### Answer-layer correctness (ROADMAP B, C — now done)
- `ask --since YEAR`; dedup representative prefers newer publication on confidence ties (B)
- The study's representative `n=` claim joins its attributions; `ask` shows `[2025, n=1009]` (C)
- **Bug fix found on the way:** a `%` claim and an `n=` claim extracted from the same sentence collided on claim id, so sample sizes were silently dropped at insert. Identity now includes unit + value.

### Semantic clustering (E) + poll-of-polls aggregation (D — now done)
- `clustering.py`: offline deterministic bilingual concept-cosine clustering ('Atomausstieg rückgängig machen' ↔ 'Return to nuclear power'), `embedder=` hook for a future pgvector backend
- `aggregate.py` + new `answer <query>` CLI: recency- (3y half-life) and sample-size- (√(n/1000), clamped) weighted mean per (question-cluster, position), always with spread / poll count / year range / Σn
- `search_attributions_semantic`: German queries (`ask klimaschutzgesetz`) now reach the English-normalized questions via a concept-similarity fallback

### Monitoring v1 (watches + opinion digest)
- Migration 0009: `watches`, `watch_snapshots`
- `watch add/list/rm`; `digest [--out]` reports ≥5pt shifts and newly tracked questions vs the previous snapshot (fuzzy cluster matching across phrasing drift)
- Scheduled workflow now uploads `opinion-digest.md` per run

### Research products
- `dossier <q> [--out]`: citable Markdown report — summary with spread, per-finding table (year/n/population/institute), method caveats, provenance appendix
- `gaps [--topic]`: evidence-gap table (stale / single-source / no-percentage clusters)
- `policy-gap --topic X`: **opinion–policy gap** — aggregated opinion vs ingested Bundestag DIP Drucksachen (flagship democratic-accountability view, v1 juxtaposition)
- `export --out DIR`: open dataset (findings.csv + studies.csv + manifest; facts and links only, no full texts)

### Bundestag DIP source
- `discovery/bundestag_dip.py`: catalog-style source over the DIP `/drucksache` API, fixture-tested, cursor-paginated, in the scheduled crawl. Uses the Bundestag's published public API key; `DIP_API_KEY` secret overrides.

## Verification

End-to-end on a real Postgres 16: 6-source fixture ingest (incl. DIP) → claims → offline attribution (24 triples / 9 studies, RUNBOOK §3.5b path) → `ask`/`answer`/`dossier`/`gaps`/`policy-gap`/`export` → digest snapshot cycle (baseline → shift detection fires → settles at 0 news). Three real defects surfaced by that run and fixed with regression tests: the claim-id collision, the ILIKE language miss, and a cluster over-merge (nine climate questions in one cluster) fixed by recalibrating the concept weight.

## Still machine-bound (needs maintainer)

- `SCRAPER_POSTGRES_URL` repo secret → activates the scheduled crawl + digest (RUNBOOK §1.1)
- Live crawl/fulltext from a networked machine (this dev environment's proxy blocks non-registry hosts)
- Optional: `DIP_API_KEY` (public key rotates), `ANTHROPIC_API_KEY` (live attribution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017TaRQhhedbz5j3gzgB1dud