### PR TITLE
scripts: one-command Claude token rotation (rotate-claude-token.ps1)

### DIFF
--- a/docs/study_scraper/AUTONOMY.md
+++ b/docs/study_scraper/AUTONOMY.md
@@ -117,7 +117,7 @@ laptop at all — point it at `POSTGRES_URL` as a Streamlit secret.
 | `prepared statement "…" already exists` | using Transaction pooler (6543) | switch to Session pooler (5432) |
 | attribute step "queue empty" | no claims yet, or all attributed | expected — run a crawl first |
 | attribute fails auth | bad/expired OAuth token | re-run `claude setup-token`, update the secret |
-| agent run RED, `needs-human` ops issue filed | OAuth token expired — the self-healing check (`.github/scripts/check_agent_result.sh`) caught a no-op agent | rotate `CLAUDE_CODE_OAUTH_TOKEN`, re-run, close the issue |
+| agent run RED, `needs-human` ops issue filed | OAuth token expired — the self-healing check (`.github/scripts/check_agent_result.sh`) caught a no-op agent | one command: `powershell -File scripts/rotate-claude-token.ps1` (login → secret update → wakes the agents; the issue auto-closes) |
 | agent runs green but do nothing (pre-fix history) | claude-code-action exits 0 even when the model call errors | fixed: every Claude workflow now verifies the execution output and fails loudly |
 | cron never fires | workflow only on a feature branch | merge to `main` (default branch) |
 | one source errors | upstream API hiccup | non-fatal by design; next run retries |

--- a/scripts/rotate-claude-token.ps1
+++ b/scripts/rotate-claude-token.ps1
@@ -1,0 +1,63 @@
+# rotate-claude-token.ps1 — refresh the agent team's Claude credential
+# and revive the automation in one command.
+#
+# What it does:
+#   1. Runs `claude setup-token` (browser login — the only manual moment).
+#   2. Auto-captures the printed token (or asks you to paste it).
+#   3. Updates the GitHub repo secret CLAUDE_CODE_OAUTH_TOKEN.
+#   4. Kicks scheduled-attribute + agent-develop so the team wakes now
+#      instead of at the next cron. The self-healing check then closes
+#      the ops issue (#24-style ticket) automatically on the first green run.
+#
+# One-time prerequisites:
+#   winget install GitHub.cli        # then: gh auth login
+#   irm https://claude.ai/install.ps1 | iex   # Claude Code CLI
+#
+# Usage (from anywhere):
+#   powershell -ExecutionPolicy Bypass -File scripts\rotate-claude-token.ps1
+
+param(
+    [string]$Repo = "cfischa/elt_data4transformation"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Find-Claude {
+    if (Get-Command claude -ErrorAction SilentlyContinue) { return "claude" }
+    $npmShim = Join-Path $env:APPDATA "npm\claude.cmd"
+    if (Test-Path $npmShim) { return $npmShim }
+    throw "claude CLI not found. Install it:  irm https://claude.ai/install.ps1 | iex"
+}
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw "GitHub CLI not found. Install:  winget install GitHub.cli  then:  gh auth login"
+}
+
+$claude = Find-Claude
+Write-Host ">> Generating a fresh subscription token (your browser will open)..." -ForegroundColor Cyan
+
+# Show output AND capture it, so interactive prompts stay visible.
+$raw = & $claude setup-token 2>&1 | Tee-Object -Variable capturedLines | Out-String
+
+# Claude Code OAuth tokens look like sk-ant-oat01-... — grab the last match.
+$matches = [regex]::Matches($raw, "sk-ant-[A-Za-z0-9_\-]{20,}")
+if ($matches.Count -gt 0) {
+    $token = $matches[$matches.Count - 1].Value
+    Write-Host ">> Token captured automatically." -ForegroundColor Green
+} else {
+    Write-Host ">> Could not auto-capture the token from the output." -ForegroundColor Yellow
+    $token = Read-Host "Paste the token that 'claude setup-token' printed"
+}
+if ([string]::IsNullOrWhiteSpace($token)) { throw "No token provided — aborting." }
+
+Write-Host ">> Updating repo secret CLAUDE_CODE_OAUTH_TOKEN on $Repo ..." -ForegroundColor Cyan
+$token | gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo $Repo
+if ($LASTEXITCODE -ne 0) { throw "gh secret set failed (is gh authenticated? run: gh auth login)" }
+
+Write-Host ">> Waking the agents now (instead of waiting for the next cron)..." -ForegroundColor Cyan
+gh workflow run scheduled-attribute --repo $Repo | Out-Null
+gh workflow run agent-develop      --repo $Repo | Out-Null
+
+Write-Host ""
+Write-Host "Done. The self-healing check auto-closes the ops issue on the first green run." -ForegroundColor Green
+Write-Host "Watch progress:  gh run list --repo $Repo --limit 5"


### PR DESCRIPTION
## What

One PowerShell command to rotate the expiring `CLAUDE_CODE_OAUTH_TOKEN` — the only recurring manual step in the automation.

`scripts/rotate-claude-token.ps1`:
1. Runs `claude setup-token` (browser login — the only manual moment).
2. Auto-captures the printed `sk-ant-…` token from the output (falls back to a paste prompt).
3. Updates the repo secret `CLAUDE_CODE_OAUTH_TOKEN` via `gh secret set`.
4. Dispatches `scheduled-attribute` + `agent-develop` so the agent team wakes immediately instead of waiting for the next cron; the self-healing check then auto-closes the ops issue on the first green run.

One-time prerequisites (documented in the script header): `winget install GitHub.cli` + `gh auth login`, and the Claude Code CLI.

Also updates the failure-modes table in `docs/study_scraper/AUTONOMY.md` to point at the script.

## Why

Token expiry is the single failure mode that stalls the whole agent loop (see issue #24). This turns recovery into one command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_