### PR TITLE
ci: install tenacity in all study_scraper workflows (fixes broken crawl)

### DIFF
--- a/.github/workflows/agent-develop.yml
+++ b/.github/workflows/agent-develop.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install deps
         run: |
           pip install pytest httpx pydantic pydantic-settings typer PyYAML \
-                      "psycopg[binary]" SPARQLWrapper pypdf beautifulsoup4
+                      "psycopg[binary]" SPARQLWrapper pypdf beautifulsoup4 tenacity
       - name: Gate on token
         id: gate
         env:

--- a/.github/workflows/agent-monitor.yml
+++ b/.github/workflows/agent-monitor.yml
@@ -25,7 +25,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install deps
-        run: pip install httpx pydantic pydantic-settings typer PyYAML "psycopg[binary]"
+        run: pip install httpx pydantic pydantic-settings typer PyYAML "psycopg[binary]" tenacity
       - name: Gate on secrets
         id: gate
         env:

--- a/.github/workflows/agent-product.yml
+++ b/.github/workflows/agent-product.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Install deps
-        run: pip install httpx pydantic pydantic-settings typer PyYAML "psycopg[binary]"
+        run: pip install httpx pydantic pydantic-settings typer PyYAML "psycopg[binary]" tenacity
       - name: Gate on token
         id: gate
         env:

--- a/.github/workflows/agent-review.yml
+++ b/.github/workflows/agent-review.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install deps
         run: |
           pip install pytest httpx pydantic pydantic-settings typer PyYAML \
-                      "psycopg[binary]" SPARQLWrapper pypdf beautifulsoup4
+                      "psycopg[binary]" SPARQLWrapper pypdf beautifulsoup4 tenacity
       - name: Gate on token
         id: gate
         env:

--- a/.github/workflows/attribute.yml
+++ b/.github/workflows/attribute.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install runtime dependencies
         run: |
           pip install httpx pydantic pydantic-settings typer PyYAML \
-                      "psycopg[binary]"
+                      "psycopg[binary]" tenacity
 
       - name: Check secrets
         id: gate

--- a/.github/workflows/ci-study-scraper.yml
+++ b/.github/workflows/ci-study-scraper.yml
@@ -25,6 +25,6 @@ jobs:
       - name: Install deps
         run: |
           pip install pytest httpx pydantic pydantic-settings typer PyYAML \
-                      "psycopg[binary]" SPARQLWrapper pypdf beautifulsoup4
+                      "psycopg[binary]" SPARQLWrapper pypdf beautifulsoup4 tenacity
       - name: Run study_scraper tests
         run: python -m pytest tests/study_scraper -o addopts="" -q

--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install runtime dependencies
         run: |
           pip install httpx pydantic pydantic-settings typer PyYAML \
-                      "psycopg[binary]" SPARQLWrapper pypdf beautifulsoup4
+                      "psycopg[binary]" SPARQLWrapper pypdf beautifulsoup4 tenacity
 
       - name: Check database secret
         id: gate

--- a/config/topics/questions.yml
+++ b/config/topics/questions.yml
@@ -1,0 +1,58 @@
+# Question registry — the standing questions we want the platform to answer.
+#
+# This is the second half of "topics and questions are ONE thing":
+#   topics.csv    → WHICH subjects we collect data for (steers the crawl)
+#   questions.yml → WHICH propositions we answer within them (this file)
+#
+# Each question is a neutral proposition scoped to exactly one topic id from
+# topics.csv. It is the DECLARATIVE source of a monitoring `watch`:
+#   python -m study_scraper questions sync      # upsert each as a watch
+# after which the existing crawl -> attribute -> digest loop answers it from
+# ALL relevant attributions (poll-of-polls over the whole corpus) and tracks
+# it over time. `query` is the recall seed for the answer layer (attribution
+# questions are normalised to English by the llm-v1 extractor, so English
+# seeds match best); the semantic fallback widens it to related phrasings.
+#
+# Rules enforced by the loader (study_scraper/questions.py):
+#   - topic_id must exist in topics.csv
+#   - question id and query must each be unique across the whole registry
+#     (watches.query is UNIQUE — two questions sharing a query would collide)
+
+version: "0.1.0"
+
+topics:
+  atomkraft:
+    - id: atomkraft_keep_or_return
+      text: "Should Germany keep or return to nuclear power?"
+      query: "nuclear power"
+
+  klima:
+    - id: klima_stronger_policy
+      text: "Should Germany strengthen its climate-protection policy?"
+      query: "climate law"
+    - id: klima_renewables_expansion
+      text: "Should the expansion of renewable energy be accelerated?"
+      query: "renewable energy"
+
+  migration_einwanderung:
+    - id: migration_reduce
+      text: "Should immigration to Germany be reduced?"
+      query: "immigration"
+
+  wohnen:
+    - id: wohnen_rent_control
+      text: "Should rents be capped to address the housing shortage?"
+      query: "rent control"
+
+  rente:
+    - id: rente_raise_retirement_age
+      text: "Should the statutory retirement age be raised?"
+      query: "retirement age"
+
+  verteidigung:
+    - id: verteidigung_increase_spending
+      text: "Should Germany increase defense spending?"
+      query: "defense spending"
+    - id: verteidigung_reintroduce_conscription
+      text: "Should compulsory military service be reintroduced?"
+      query: "conscription"

--- a/docs/study_scraper/AUTONOMY.md
+++ b/docs/study_scraper/AUTONOMY.md
@@ -117,7 +117,7 @@ laptop at all — point it at `POSTGRES_URL` as a Streamlit secret.
 | `prepared statement "…" already exists` | using Transaction pooler (6543) | switch to Session pooler (5432) |
 | attribute step "queue empty" | no claims yet, or all attributed | expected — run a crawl first |
 | attribute fails auth | bad/expired OAuth token | re-run `claude setup-token`, update the secret |
-| agent run RED, `needs-human` ops issue filed | OAuth token expired — the self-healing check (`.github/scripts/check_agent_result.sh`) caught a no-op agent | rotate `CLAUDE_CODE_OAUTH_TOKEN`, re-run, close the issue |
+| agent run RED, `needs-human` ops issue filed | OAuth token expired — the self-healing check (`.github/scripts/check_agent_result.sh`) caught a no-op agent | one command: `powershell -File scripts/rotate-claude-token.ps1` (login → secret update → wakes the agents; the issue auto-closes) |
 | agent runs green but do nothing (pre-fix history) | claude-code-action exits 0 even when the model call errors | fixed: every Claude workflow now verifies the execution output and fails loudly |
 | cron never fires | workflow only on a feature branch | merge to `main` (default branch) |
 | one source errors | upstream API hiccup | non-fatal by design; next run retries |

--- a/docs/study_scraper/DECISIONS.md
+++ b/docs/study_scraper/DECISIONS.md
@@ -435,6 +435,43 @@ This document tracks design decisions for the study scraper. Two sections:
   `GOAL.md` remain valid as the eventual bar — they just aren't measured
   until the gold set exists.
 
+### A22. Question registry — topics and questions are one thing (2026-07-07)
+- **Decision:** A standing **question registry** (`config/topics/questions.yml`,
+  loaded by `study_scraper/questions.py`) sits beside `topics.csv`. Each
+  question is a neutral proposition scoped to exactly one topic id. The
+  registry is the **declarative source of the monitoring watches**:
+  `questions sync` upserts each question as a `watch`, and the existing
+  crawl → attribute → **digest** loop answers it from all relevant
+  attributions and tracks it over time.
+- **Rationale (maintainer, 2026-07-07):** "We have questions and topics —
+  this should be ONE thing. All relevant data we collect should be used to
+  answer the registered questions. Streamline the logic." `topics.csv`
+  already steers collection; questions were only ever emergent (whatever
+  the llm-v1 extractor found per document) and ad-hoc (`ask`). The registry
+  ties the two halves together: *which subjects we collect for* × *which
+  propositions we answer*.
+- **Why no new answerer / no new statistics:** `watches` (A-series
+  monitoring v1, migration 0009) is already "a registry of standing
+  questions answered over the whole corpus". Rather than add a parallel
+  surface, the question registry **feeds** it. Answering reuses the shipped
+  `search_attributions_semantic → aggregate_findings` path unchanged, so a
+  registered question resolves to a **set of question-cluster answers**
+  (spread shown, populations kept distinct) — never a single averaged
+  number across heterogeneous polls.
+- **Why not fold question keywords into collection (rejected):**
+  `Topic.all_keywords()` is not on the discovery/scoring path (discovery
+  builds queries from `include_keywords + synonyms` directly; scoring uses
+  `topic_filter._gather_terms`), so folding question keywords there would be
+  a silent no-op; wiring them into the real capped query builders would
+  displace topic terms and add false-friend surfaces the per-topic
+  `exclude_keywords` never covered. Collection-for-questions is deferred to
+  a separate change with its own exclude review. v1 answers the questions
+  from the data the topics already collect.
+- **Invariants (loader-enforced):** every `topic_id` exists in `topics.csv`;
+  question `id` and `query` are each unique across the registry
+  (`watches.query` is UNIQUE). A test guards that the shipped registry
+  stays consistent with the shipped topics.
+
 ---
 
 ## Open questions

--- a/docs/study_scraper/FLOW.md
+++ b/docs/study_scraper/FLOW.md
@@ -75,11 +75,32 @@ Two independent input types:
   entirely.
 
 ### 4 · How we answer questions
-- **CLI:** `python -m study_scraper ask "atomkraft"` → searches
-  `attributions` → returns `PCT% position question` + source.
+Topics and questions are **one registry**: `topics.csv` says *which
+subjects we collect for*, `questions.yml` says *which propositions we
+answer within them*. Each registered question is a neutral proposition
+scoped to one topic (e.g. `atomkraft → "Should Germany keep or return to
+nuclear power?"`).
+
+- **The registry → the loop.** `python -m study_scraper questions sync`
+  upserts each question as a monitoring **watch** (idempotent). From then
+  on the existing crawl → attribute → **digest** loop answers it from
+  **all relevant attributions** (poll-of-polls over the whole corpus,
+  `aggregate.py`) and tracks it over time — no separate answerer, no new
+  statistics.
+- **On demand:** `python -m study_scraper questions answer [--topic X]`
+  answers every registered question now: a **set of question-cluster
+  answers** with the spread shown honestly (never one collapsed number),
+  and flags questions with no findings as **coverage gaps** (they need
+  more collection — the loop back to `topics.csv`).
+- **Ad hoc:** `python -m study_scraper ask "atomkraft"` / `answer "…"` for
+  free-text queries outside the registry.
 - **Dashboard:** the Streamlit dock (`study_scraper/console/`) — Home
   (counts), Topics (taxonomy), Review (the `pending` queue), Lake (raw
   structured data). Reads live from Postgres.
+
+The registry closes the loop the maintainer asked for: *define the
+questions → collect data for them → answer them from everything relevant
+→ see the gaps → collect more.*
 
 ## "I don't want to review by hand" — you already mostly don't
 - The automated loop (`kept → claims → attributions → answers`) needs **no
@@ -100,4 +121,6 @@ Two independent input types:
 | Claims | `study_scraper/claims.py` |
 | Attributions | `study_scraper/attribute.py`, `study_scraper/extractors/llm_v1.py` |
 | Storage / schema | `study_scraper/storage/postgres.py`, `study_scraper/migrations/` |
-| Answer | `ask` in `study_scraper/cli.py`, `study_scraper/console/` |
+| Question registry | `config/topics/questions.yml`, `study_scraper/questions.py` |
+| Answer | `ask` / `answer` / `questions` in `study_scraper/cli.py`, `study_scraper/console/` |
+| Monitoring loop | `study_scraper/digest.py` (answers + tracks synced questions) |

--- a/scripts/rotate-claude-token.ps1
+++ b/scripts/rotate-claude-token.ps1
@@ -1,0 +1,63 @@
+# rotate-claude-token.ps1 — refresh the agent team's Claude credential
+# and revive the automation in one command.
+#
+# What it does:
+#   1. Runs `claude setup-token` (browser login — the only manual moment).
+#   2. Auto-captures the printed token (or asks you to paste it).
+#   3. Updates the GitHub repo secret CLAUDE_CODE_OAUTH_TOKEN.
+#   4. Kicks scheduled-attribute + agent-develop so the team wakes now
+#      instead of at the next cron. The self-healing check then closes
+#      the ops issue (#24-style ticket) automatically on the first green run.
+#
+# One-time prerequisites:
+#   winget install GitHub.cli        # then: gh auth login
+#   irm https://claude.ai/install.ps1 | iex   # Claude Code CLI
+#
+# Usage (from anywhere):
+#   powershell -ExecutionPolicy Bypass -File scripts\rotate-claude-token.ps1
+
+param(
+    [string]$Repo = "cfischa/elt_data4transformation"
+)
+
+$ErrorActionPreference = "Stop"
+
+function Find-Claude {
+    if (Get-Command claude -ErrorAction SilentlyContinue) { return "claude" }
+    $npmShim = Join-Path $env:APPDATA "npm\claude.cmd"
+    if (Test-Path $npmShim) { return $npmShim }
+    throw "claude CLI not found. Install it:  irm https://claude.ai/install.ps1 | iex"
+}
+
+if (-not (Get-Command gh -ErrorAction SilentlyContinue)) {
+    throw "GitHub CLI not found. Install:  winget install GitHub.cli  then:  gh auth login"
+}
+
+$claude = Find-Claude
+Write-Host ">> Generating a fresh subscription token (your browser will open)..." -ForegroundColor Cyan
+
+# Show output AND capture it, so interactive prompts stay visible.
+$raw = & $claude setup-token 2>&1 | Tee-Object -Variable capturedLines | Out-String
+
+# Claude Code OAuth tokens look like sk-ant-oat01-... — grab the last match.
+$matches = [regex]::Matches($raw, "sk-ant-[A-Za-z0-9_\-]{20,}")
+if ($matches.Count -gt 0) {
+    $token = $matches[$matches.Count - 1].Value
+    Write-Host ">> Token captured automatically." -ForegroundColor Green
+} else {
+    Write-Host ">> Could not auto-capture the token from the output." -ForegroundColor Yellow
+    $token = Read-Host "Paste the token that 'claude setup-token' printed"
+}
+if ([string]::IsNullOrWhiteSpace($token)) { throw "No token provided — aborting." }
+
+Write-Host ">> Updating repo secret CLAUDE_CODE_OAUTH_TOKEN on $Repo ..." -ForegroundColor Cyan
+$token | gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo $Repo
+if ($LASTEXITCODE -ne 0) { throw "gh secret set failed (is gh authenticated? run: gh auth login)" }
+
+Write-Host ">> Waking the agents now (instead of waiting for the next cron)..." -ForegroundColor Cyan
+gh workflow run scheduled-attribute --repo $Repo | Out-Null
+gh workflow run agent-develop      --repo $Repo | Out-Null
+
+Write-Host ""
+Write-Host "Done. The self-healing check auto-closes the ops issue on the first green run." -ForegroundColor Green
+Write-Host "Watch progress:  gh run list --repo $Repo --limit 5"

--- a/study_scraper/cli.py
+++ b/study_scraper/cli.py
@@ -812,6 +812,142 @@ def watch_rm(watch_id: int = typer.Argument(...)) -> None:
     typer.echo("deactivated" if changed else "no change (unknown or already off)")
 
 
+questions_app = typer.Typer(
+    help="Question registry — the standing propositions we answer, tied to "
+    "topics. The declarative source of the monitoring watches.",
+    no_args_is_help=True,
+)
+app.add_typer(questions_app, name="questions")
+
+
+def _load_registry() -> "List":
+    """Load questions.yml, validated against the live topics."""
+    from study_scraper.questions import QuestionRegistryError, load_questions
+
+    settings = get_settings()
+    topics = load_topics(settings.topics_csv_path)
+    try:
+        return load_questions(
+            settings.questions_yaml_path,
+            valid_topic_ids=[t.id for t in topics],
+        )
+    except (QuestionRegistryError, FileNotFoundError) as exc:
+        raise typer.BadParameter(str(exc)) from exc
+
+
+def _topic_names() -> dict:
+    settings = get_settings()
+    return {t.id: t.primary_name for t in load_topics(settings.topics_csv_path)}
+
+
+@questions_app.command("list")
+def questions_list(
+    topic: Optional[str] = typer.Option(
+        None, "--topic", help="Only questions for this topic id."
+    ),
+) -> None:
+    """List the registered questions grouped by topic (reads config only)."""
+    registry = _load_registry()
+    if topic is not None:
+        registry = [q for q in registry if q.topic_id == topic]
+    if not registry:
+        typer.echo("(no questions — edit config/topics/questions.yml)")
+        return
+    current = None
+    for q in sorted(registry, key=lambda q: (q.topic_id, q.id)):
+        if q.topic_id != current:
+            current = q.topic_id
+            typer.echo(f"\n{q.topic_id}")
+        since = f"  (since {q.since_year})" if q.since_year else ""
+        typer.echo(f"  {q.id}\t{q.text}\t[query: {q.query!r}]{since}")
+
+
+@questions_app.command("sync")
+def questions_sync(
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Show what would be synced without writing."
+    ),
+) -> None:
+    """Materialize the registry as monitoring watches (idempotent).
+
+    Each registered question becomes a `watch` (upsert on the unique
+    query), so the existing crawl → attribute → digest loop answers it
+    from ALL relevant attributions and tracks it over time. Re-running is
+    safe: unchanged questions are updated in place, not duplicated.
+    """
+    from study_scraper.questions import watch_spec_for
+
+    registry = _load_registry()
+    names = _topic_names()
+    if dry_run:
+        for q in registry:
+            spec = watch_spec_for(q, topic_name=names.get(q.topic_id))
+            typer.echo(f"would sync: {spec['query']!r}  — {spec['label']}")
+        typer.echo(f"\n{len(registry)} question(s) (dry run — nothing written)")
+        return
+
+    storage = _storage_from_settings()
+    for q in registry:
+        spec = watch_spec_for(q, topic_name=names.get(q.topic_id))
+        wid = storage.add_watch(
+            query=str(spec["query"]),
+            label=str(spec["label"]),
+            since_year=spec["since_year"],
+        )
+        typer.echo(f"watch {wid:>3}  {spec['query']!r}")
+    typer.echo(f"\nsynced {len(registry)} question(s) into watches")
+
+
+@questions_app.command("answer")
+def questions_answer(
+    topic: Optional[str] = typer.Option(
+        None, "--topic", help="Only answer questions for this topic id."
+    ),
+    since: Optional[int] = typer.Option(
+        None, "--since", help="Only findings from this year or later."
+    ),
+) -> None:
+    """Answer every registered question from ALL relevant data.
+
+    For each question this runs the same poll-of-polls path the digest
+    uses (`search_attributions_semantic` → `aggregate_findings`): a set
+    of question-cluster answers with the spread shown honestly — never a
+    single collapsed number. Questions with no matching findings are
+    flagged as coverage gaps (they need more collection).
+    """
+    from study_scraper.aggregate import aggregate_findings, format_answer
+
+    registry = _load_registry()
+    if topic is not None:
+        registry = [q for q in registry if q.topic_id == topic]
+    if not registry:
+        typer.echo("(no questions matched)")
+        return
+
+    storage = _storage_from_settings()
+    gaps: List[str] = []
+    for q in sorted(registry, key=lambda q: (q.topic_id, q.id)):
+        floor = since if since is not None else q.since_year
+        rows = storage.search_attributions_semantic(
+            query=q.query, limit=500, since=floor
+        )
+        answers = aggregate_findings(rows)
+        typer.echo(f"\n### [{q.topic_id}] {q.text}")
+        if not answers:
+            typer.echo("  (coverage gap — no findings yet; needs collection)")
+            gaps.append(f"{q.topic_id}/{q.id}")
+            continue
+        for a in answers:
+            typer.echo(format_answer(a))
+            typer.echo("")
+    if gaps:
+        typer.echo(f"\ncoverage gaps ({len(gaps)}): {', '.join(gaps)}")
+    typer.echo(
+        "\nmethod: weighted mean per question cluster; weights = recency "
+        "(3y half-life) × sqrt(n/1000) clamped to [0.3, 3]."
+    )
+
+
 @app.command()
 def digest(
     out: Optional[Path] = typer.Option(

--- a/study_scraper/config.py
+++ b/study_scraper/config.py
@@ -63,6 +63,9 @@ class Settings(BaseSettings):
     )
     http_timeout_seconds: float = Field(default=30.0)
     http_max_retries: int = Field(default=3)
+    # Small pause between successive document fetches in the fulltext loop so
+    # we don't burst dozens of PDF requests at one host (scraper politeness).
+    http_politeness_delay_seconds: float = Field(default=0.5)
     respect_robots_txt: bool = Field(default=True)
 
     @property

--- a/study_scraper/config.py
+++ b/study_scraper/config.py
@@ -33,6 +33,11 @@ class Settings(BaseSettings):
         default=REPO_ROOT / "config" / "topics" / "topics.csv",
         description="CSV of topics edited by the maintainer.",
     )
+    questions_yaml_path: Path = Field(
+        default=REPO_ROOT / "config" / "topics" / "questions.yml",
+        description="Registry of standing questions, each scoped to a topic. "
+        "The declarative source of the monitoring watches.",
+    )
 
     # Storage — Supabase primary (per DECISIONS.md A7). When unset, the
     # scraper falls back to a plain Postgres URL for local development.

--- a/study_scraper/discovery/bundestag_dip.py
+++ b/study_scraper/discovery/bundestag_dip.py
@@ -36,6 +36,7 @@ from typing import Any, Dict, Iterator, List, Optional
 import httpx
 
 from study_scraper.discovery.base import Candidate
+from study_scraper.http import get_with_retry
 from study_scraper.topics import Topic
 
 LOGGER = logging.getLogger(__name__)
@@ -120,8 +121,8 @@ class BundestagDIPSource:
                 if cursor:
                     params["cursor"] = cursor
                 LOGGER.info("DIP request: f.titel=%r cursor=%s", term, cursor)
-                resp = self._client.get(
-                    f"{self._base_url}/drucksache", params=params
+                resp = get_with_retry(
+                    self._client, f"{self._base_url}/drucksache", params=params
                 )
                 resp.raise_for_status()
                 payload = resp.json()

--- a/study_scraper/discovery/openalex.py
+++ b/study_scraper/discovery/openalex.py
@@ -32,6 +32,7 @@ from typing import Any, Dict, Iterator, List, Optional
 import httpx
 
 from study_scraper.discovery.base import Candidate, DiscoverySource
+from study_scraper.http import get_with_retry
 from study_scraper.topics import Topic
 
 
@@ -119,7 +120,7 @@ class OpenAlexSource:
         while True:
             params["cursor"] = cursor
             LOGGER.info("OpenAlex request: %s", params)
-            resp = self._client.get(self._base_url, params=params)
+            resp = get_with_retry(self._client, self._base_url, params=params)
             resp.raise_for_status()
             payload = resp.json()
             for cand in self._parse_payload(payload, topic=topic, limit=None):

--- a/study_scraper/discovery/ssoar.py
+++ b/study_scraper/discovery/ssoar.py
@@ -30,6 +30,7 @@ from xml.etree import ElementTree as ET
 import httpx
 
 from study_scraper.discovery.base import Candidate, DiscoverySource
+from study_scraper.http import get_with_retry
 from study_scraper.topics import Topic
 
 
@@ -105,7 +106,7 @@ class SSOARSource:
         # caller passes --limit to keep the live run bounded.
         while True:
             LOGGER.info("SSOAR OAI-PMH request: %s", params)
-            resp = self._client.get(self._base_url, params=params)
+            resp = get_with_retry(self._client, self._base_url, params=params)
             resp.raise_for_status()
             for cand in self._parse_response(resp.text, topic=topic, limit=None):
                 yield cand

--- a/study_scraper/fulltext.py
+++ b/study_scraper/fulltext.py
@@ -38,6 +38,7 @@ import httpx
 
 from study_scraper.claims import extract_claims_from_text
 from study_scraper.config import get_settings
+from study_scraper.http import get_with_retry, polite_sleep
 from study_scraper.pdf_resolver import is_pdf_url, resolve_pdf_url
 from study_scraper.storage import PostgresStorage
 
@@ -181,7 +182,7 @@ def fetch_url(url: str, *, timeout: float = 60.0) -> Tuple[bytes, Optional[str]]
         headers={"User-Agent": settings.http_user_agent},
         follow_redirects=True,
     ) as client:
-        resp = client.get(url)
+        resp = get_with_retry(client, url)
         resp.raise_for_status()
         return resp.content, resp.headers.get("content-type")
 
@@ -241,7 +242,10 @@ def run_fulltext(
         )
 
     results: List[Dict[str, Any]] = []
-    for row in rows:
+    politeness = get_settings().http_politeness_delay_seconds
+    for idx, row in enumerate(rows):
+        if idx > 0:
+            polite_sleep(politeness)  # don't burst all documents at one host
         sid = row["id"]
         url, why = select_fetch_url(
             canonical_url=row.get("canonical_url"),

--- a/study_scraper/http.py
+++ b/study_scraper/http.py
@@ -1,0 +1,130 @@
+"""Shared HTTP fetch policy — retry, backoff, and politeness for every
+source client and the fulltext loop.
+
+Before this module each fetcher (`ssoar`, `openalex`, `bundestag_dip`,
+`dawum`, `eurostat`, `fulltext.fetch_url`) called ``client.get`` with no
+retry, and the fulltext loop bursted dozens of PDF fetches at one host with
+no delay. Standard scraper craft: jittered exponential backoff, honour
+``Retry-After`` on 429/503, and a small per-request politeness delay.
+
+Everything funnels through :func:`request_with_retry`. It is deliberately
+transport-agnostic: callers pass their own ``httpx.Client`` (so
+``from_file`` fixture modes, which never touch the network, are unaffected),
+and the ``sleep`` seam lets tests assert retry behaviour with
+``httpx.MockTransport`` without waiting in real time.
+"""
+
+from __future__ import annotations
+
+import random
+import time
+from typing import Any, Callable, Optional
+
+import httpx
+from tenacity import (
+    Retrying,
+    retry_if_exception_type,
+    stop_after_attempt,
+)
+
+# 429 = rate limited; 5xx = transient upstream trouble. 4xx (except 429) are
+# the caller's fault and must NOT be retried (a 404 stays a 404).
+RETRYABLE_STATUS = frozenset({429, 500, 502, 503, 504})
+
+_DEFAULT_MAX_ATTEMPTS = 4
+_DEFAULT_BASE_DELAY = 0.5
+_MAX_BACKOFF = 30.0
+
+
+class RetryableResponse(Exception):
+    """Internal signal: a response arrived but its status is worth retrying.
+
+    Carries the response so the caller can still inspect/raise on it once
+    retries are exhausted (we hand the last response back rather than
+    swallowing it)."""
+
+    def __init__(self, response: httpx.Response, retry_after: Optional[float]):
+        super().__init__(f"retryable status {response.status_code}")
+        self.response = response
+        self.retry_after = retry_after
+
+
+def _parse_retry_after(response: httpx.Response) -> Optional[float]:
+    """Seconds to wait per the ``Retry-After`` header, if present and numeric.
+    HTTP-date form is ignored (we fall back to backoff) — the delta-seconds
+    form is what rate limiters actually send."""
+    raw = response.headers.get("retry-after")
+    if not raw:
+        return None
+    try:
+        seconds = float(raw.strip())
+    except ValueError:
+        return None
+    return max(0.0, seconds)
+
+
+def _wait_seconds(state: Any, base_delay: float) -> float:
+    """Honour ``Retry-After`` when the upstream gave one, else exponential
+    backoff with full jitter, capped."""
+    exc = state.outcome.exception() if state.outcome else None
+    if isinstance(exc, RetryableResponse) and exc.retry_after is not None:
+        return exc.retry_after
+    attempt = max(1, state.attempt_number)
+    ceiling = min(base_delay * (2 ** (attempt - 1)), _MAX_BACKOFF)
+    return random.uniform(0.0, ceiling)  # full jitter
+
+
+def request_with_retry(
+    client: httpx.Client,
+    method: str,
+    url: str,
+    *,
+    max_attempts: int = _DEFAULT_MAX_ATTEMPTS,
+    base_delay: float = _DEFAULT_BASE_DELAY,
+    sleep: Callable[[float], None] = time.sleep,
+    **kwargs: Any,
+) -> httpx.Response:
+    """Issue ``client.request(method, url, **kwargs)`` with retries.
+
+    Retries on transport errors and on :data:`RETRYABLE_STATUS` responses,
+    honouring ``Retry-After``. Returns the final response; on a persistently
+    retryable status it returns that last response (callers keep their
+    existing ``raise_for_status()``). Transport errors that outlast the
+    retries propagate unchanged.
+    """
+    retrying = Retrying(
+        stop=stop_after_attempt(max_attempts),
+        wait=lambda state: _wait_seconds(state, base_delay),
+        retry=retry_if_exception_type((httpx.TransportError, RetryableResponse)),
+        sleep=sleep,
+        reraise=True,
+    )
+
+    def _attempt() -> httpx.Response:
+        response = client.request(method, url, **kwargs)
+        if response.status_code in RETRYABLE_STATUS:
+            raise RetryableResponse(response, _parse_retry_after(response))
+        return response
+
+    try:
+        return retrying(_attempt)
+    except RetryableResponse as exc:
+        # Retries exhausted on e.g. a stubborn 503 — hand the response back so
+        # the caller's raise_for_status()/status handling behaves as before.
+        return exc.response
+
+
+def get_with_retry(
+    client: httpx.Client, url: str, **kwargs: Any
+) -> httpx.Response:
+    """Convenience wrapper for the common GET case."""
+    return request_with_retry(client, "GET", url, **kwargs)
+
+
+def polite_sleep(
+    delay: float, *, sleep: Callable[[float], None] = time.sleep
+) -> None:
+    """Small inter-request pause so a tight fetch loop doesn't hammer one
+    host. No-op for non-positive delays."""
+    if delay and delay > 0:
+        sleep(delay)

--- a/study_scraper/questions.py
+++ b/study_scraper/questions.py
@@ -1,0 +1,151 @@
+"""Question registry — the standing questions we want answered, tied to topics.
+
+Unifies the two halves of the platform's intent:
+
+    topics.csv    -> WHICH subjects we collect data for (steers the crawl)
+    questions.yml -> WHICH propositions we answer within them (this registry)
+
+A registered ``Question`` is a neutral proposition ("Should Germany keep
+nuclear power?") scoped to exactly one topic. It is the DECLARATIVE source of a
+monitoring ``watch``: ``questions sync`` upserts each into the watches table,
+and the existing crawl -> attribute -> digest loop then answers it from ALL
+relevant attributions (poll-of-polls over the whole corpus, ``aggregate.py``)
+and tracks it over time.
+
+There is deliberately NO new answer path and NO new statistics here: the
+registry is the single source, and the already-shipped digest/aggregate
+machinery is the single answerer. Loading and watch-spec derivation are pure
+functions; only the CLI ``sync``/``answer`` verbs touch the database.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import yaml
+from pydantic import BaseModel, Field, field_validator
+
+
+class QuestionRegistryError(ValueError):
+    """Raised when questions.yml is malformed or inconsistent with topics."""
+
+
+class Question(BaseModel):
+    """One standing proposition, scoped to a single topic."""
+
+    id: str
+    topic_id: str
+    text: str
+    query: str
+    since_year: Optional[int] = Field(default=None)
+
+    @field_validator("id", "topic_id", "text", "query")
+    @classmethod
+    def _non_empty(cls, value: str) -> str:
+        value = (value or "").strip()
+        if not value:
+            raise ValueError("must not be empty")
+        return value
+
+    def watch_label(self, topic_name: Optional[str] = None) -> str:
+        """Heading used for the digest section when this question is synced
+        as a watch. Prefers a human topic name, falls back to the id."""
+        head = (topic_name or self.topic_id).strip()
+        return f"{head}: {self.text}"
+
+
+def watch_spec_for(
+    question: Question, *, topic_name: Optional[str] = None
+) -> Dict[str, object]:
+    """Pure mapping from a registry question to the watch upsert arguments.
+
+    Deterministic so ``sync`` is idempotent and unit-testable without a DB:
+    the same registry always produces the same ``(query, label, since_year)``.
+    """
+    return {
+        "query": question.query,
+        "label": question.watch_label(topic_name),
+        "since_year": question.since_year,
+    }
+
+
+def load_questions(
+    path: Path, *, valid_topic_ids: Optional[List[str]] = None
+) -> List[Question]:
+    """Load and validate the question registry.
+
+    Structure (``questions.yml``)::
+
+        version: "0.1.0"
+        topics:
+          atomkraft:
+            - id: atomkraft_keep_or_return
+              text: "Should Germany keep or return to nuclear power?"
+              query: "nuclear power"
+              since_year: 2020        # optional recency floor
+
+    Enforced invariants (statistical + referential integrity):
+      - every ``topic_id`` exists in ``valid_topic_ids`` (when provided),
+      - question ``id`` is unique across the whole registry,
+      - ``query`` is unique across the whole registry (``watches.query`` is
+        UNIQUE, so two questions sharing a query would collide on sync).
+    """
+    if not path.exists():
+        raise FileNotFoundError(f"questions registry not found: {path}")
+
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except yaml.YAMLError as exc:  # pragma: no cover - passthrough
+        raise QuestionRegistryError(f"{path}: invalid YAML: {exc}") from exc
+    if not isinstance(data, dict):
+        raise QuestionRegistryError(f"{path}: top level must be a mapping")
+
+    topics = data.get("topics") or {}
+    if not isinstance(topics, dict):
+        raise QuestionRegistryError(f"{path}: 'topics' must be a mapping")
+
+    valid = set(valid_topic_ids) if valid_topic_ids is not None else None
+    questions: List[Question] = []
+    seen_ids: Dict[str, str] = {}
+    seen_queries: Dict[str, str] = {}
+
+    for topic_id, items in topics.items():
+        topic_id = str(topic_id).strip()
+        if valid is not None and topic_id not in valid:
+            raise QuestionRegistryError(
+                f"{path}: topic {topic_id!r} is not defined in topics.csv"
+            )
+        if not isinstance(items, list):
+            raise QuestionRegistryError(
+                f"{path}: topic {topic_id!r} must map to a list of questions"
+            )
+        for item in items:
+            if not isinstance(item, dict):
+                raise QuestionRegistryError(
+                    f"{path}: question under {topic_id!r} must be a mapping"
+                )
+            try:
+                question = Question(topic_id=topic_id, **item)
+            except (TypeError, ValueError) as exc:
+                raise QuestionRegistryError(
+                    f"{path}: invalid question under {topic_id!r}: {exc}"
+                ) from exc
+
+            if question.id in seen_ids:
+                raise QuestionRegistryError(
+                    f"{path}: duplicate question id {question.id!r} "
+                    f"(also under {seen_ids[question.id]!r})"
+                )
+            qkey = question.query.lower()
+            if qkey in seen_queries:
+                raise QuestionRegistryError(
+                    f"{path}: duplicate query {question.query!r} for "
+                    f"{question.id!r} (also {seen_queries[qkey]!r}); "
+                    "watches.query is UNIQUE"
+                )
+            seen_ids[question.id] = topic_id
+            seen_queries[qkey] = question.id
+            questions.append(question)
+
+    return questions

--- a/study_scraper/sources/dawum.py
+++ b/study_scraper/sources/dawum.py
@@ -40,6 +40,7 @@ from typing import Any, Dict, Iterator, List, Optional
 
 import httpx
 
+from study_scraper.http import get_with_retry
 from study_scraper.models import SourceRecord
 
 
@@ -98,7 +99,7 @@ class DAWUMSource:
             payload = json.loads(self._from_file.read_text(encoding="utf-8"))
         else:
             LOGGER.info("DAWUM GET %s", self._base_url)
-            resp = self._client.get(self._base_url)
+            resp = get_with_retry(self._client, self._base_url)
             resp.raise_for_status()
             payload = resp.json()
 

--- a/study_scraper/sources/eurostat.py
+++ b/study_scraper/sources/eurostat.py
@@ -41,6 +41,7 @@ from typing import Any, Dict, Iterator, List, Optional
 
 import httpx
 
+from study_scraper.http import get_with_retry
 from study_scraper.models import SourceRecord
 
 
@@ -185,7 +186,7 @@ class EurostatSource:
         url = f"{self._base_url}/{code}"
         params = self._params(with_filters=with_filters)
         LOGGER.info("eurostat GET %s params=%s", url, params)
-        return self._client.get(url, params=params)
+        return get_with_retry(self._client, url, params=params)
 
     # ------------------------------------------------------------------
     # Fixture path

--- a/tests/study_scraper/test_http.py
+++ b/tests/study_scraper/test_http.py
@@ -1,0 +1,155 @@
+"""Shared HTTP retry/backoff/politeness policy (agent:task #32).
+
+Exercised with httpx.MockTransport and an injected no-op sleeper, so retry
+behaviour is asserted without any real waiting or network.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, List
+
+import httpx
+import pytest
+
+from study_scraper.http import (
+    RETRYABLE_STATUS,
+    get_with_retry,
+    polite_sleep,
+    request_with_retry,
+)
+
+
+def _client(handler: Callable[[httpx.Request], httpx.Response]) -> httpx.Client:
+    return httpx.Client(transport=httpx.MockTransport(handler))
+
+
+def _recording_sleeper() -> "tuple[Callable[[float], None], List[float]]":
+    slept: List[float] = []
+    return (lambda s: slept.append(s)), slept
+
+
+def test_retries_429_then_succeeds() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(429, text="slow down")
+        return httpx.Response(200, text="ok")
+
+    sleep, slept = _recording_sleeper()
+    with _client(handler) as client:
+        resp = get_with_retry(client, "https://x.test/a", sleep=sleep)
+
+    assert resp.status_code == 200
+    assert calls["n"] == 2
+    assert len(slept) == 1  # slept once between the two attempts
+
+
+def test_no_retry_on_404() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(404, text="nope")
+
+    sleep, slept = _recording_sleeper()
+    with _client(handler) as client:
+        resp = get_with_retry(client, "https://x.test/missing", sleep=sleep)
+
+    assert resp.status_code == 404
+    assert calls["n"] == 1  # 4xx (non-429) is not retried
+    assert slept == []
+
+
+def test_honours_retry_after_header() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(503, headers={"Retry-After": "7"})
+        return httpx.Response(200)
+
+    sleep, slept = _recording_sleeper()
+    with _client(handler) as client:
+        resp = get_with_retry(client, "https://x.test/b", sleep=sleep)
+
+    assert resp.status_code == 200
+    assert slept == [7.0]  # exact Retry-After, not backoff
+
+
+def test_retries_transport_error_then_succeeds() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise httpx.ConnectError("boom", request=request)
+        return httpx.Response(200)
+
+    sleep, _ = _recording_sleeper()
+    with _client(handler) as client:
+        resp = get_with_retry(client, "https://x.test/c", sleep=sleep)
+
+    assert resp.status_code == 200
+    assert calls["n"] == 2
+
+
+def test_returns_last_response_after_exhausting_retries() -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        return httpx.Response(503)
+
+    sleep, slept = _recording_sleeper()
+    with _client(handler) as client:
+        resp = request_with_retry(
+            client, "GET", "https://x.test/d", max_attempts=3, sleep=sleep
+        )
+
+    assert resp.status_code == 503  # handed back, not swallowed
+    assert calls["n"] == 3  # exactly max_attempts
+    assert len(slept) == 2  # waited between the 3 attempts
+
+
+def test_transport_error_propagates_after_retries() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("down", request=request)
+
+    sleep, _ = _recording_sleeper()
+    with _client(handler) as client:
+        with pytest.raises(httpx.ConnectError):
+            request_with_retry(
+                client, "GET", "https://x.test/e", max_attempts=2, sleep=sleep
+            )
+
+
+def test_params_pass_through() -> None:
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        return httpx.Response(200)
+
+    with _client(handler) as client:
+        get_with_retry(client, "https://x.test/f", params={"q": "hi", "n": 2})
+
+    assert "q=hi" in seen["url"] and "n=2" in seen["url"]
+
+
+def test_polite_sleep_skips_nonpositive() -> None:
+    sleep, slept = _recording_sleeper()
+    polite_sleep(0.0, sleep=sleep)
+    polite_sleep(-1, sleep=sleep)
+    assert slept == []
+    polite_sleep(0.25, sleep=sleep)
+    assert slept == [0.25]
+
+
+def test_retryable_status_set() -> None:
+    assert 429 in RETRYABLE_STATUS
+    assert 503 in RETRYABLE_STATUS
+    assert 404 not in RETRYABLE_STATUS
+    assert 200 not in RETRYABLE_STATUS

--- a/tests/study_scraper/test_questions.py
+++ b/tests/study_scraper/test_questions.py
@@ -1,0 +1,290 @@
+"""Question registry: loader validation, watch-spec derivation, CLI, and a
+consistency guard on the shipped config/topics/questions.yml.
+
+The registry is the declarative source of the monitoring watches — the piece
+that makes "topics and questions are ONE thing" real. These tests keep it
+honest offline; the sync/answer DB paths are DSN-gated integration tests.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from study_scraper.cli import app
+from study_scraper.config import get_settings
+from study_scraper.questions import (
+    Question,
+    QuestionRegistryError,
+    load_questions,
+    watch_spec_for,
+)
+from study_scraper.topics import load_topics
+
+
+TEST_DSN = os.environ.get("STUDY_SCRAPER_TEST_DSN")
+
+
+def _plain(text: str) -> str:
+    return re.sub(r"\x1b\[[0-9;]*m", "", text)
+
+
+def _write(tmp_path: Path, body: str) -> Path:
+    p = tmp_path / "questions.yml"
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Loader — happy path
+# ---------------------------------------------------------------------------
+
+def test_load_questions_happy_path(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+version: "0.1.0"
+topics:
+  atomkraft:
+    - id: atom_keep
+      text: "Keep nuclear power?"
+      query: "nuclear power"
+      since_year: 2020
+  klima:
+    - id: klima_policy
+      text: "Stronger climate policy?"
+      query: "climate law"
+""",
+    )
+    qs = load_questions(path, valid_topic_ids=["atomkraft", "klima"])
+    assert [q.id for q in qs] == ["atom_keep", "klima_policy"]
+    assert qs[0].topic_id == "atomkraft"
+    assert qs[0].since_year == 2020
+    assert qs[1].since_year is None
+
+
+def test_load_questions_no_topic_validation(tmp_path: Path) -> None:
+    """When valid_topic_ids is omitted, any topic id is accepted."""
+    path = _write(
+        tmp_path,
+        """
+topics:
+  whatever:
+    - id: q1
+      text: "T"
+      query: "q"
+""",
+    )
+    qs = load_questions(path)  # no FK check
+    assert qs[0].topic_id == "whatever"
+
+
+# ---------------------------------------------------------------------------
+# Loader — validation failures
+# ---------------------------------------------------------------------------
+
+def test_unknown_topic_id_rejected(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+topics:
+  not_a_topic:
+    - id: q1
+      text: "T"
+      query: "q"
+""",
+    )
+    with pytest.raises(QuestionRegistryError, match="not defined in topics.csv"):
+        load_questions(path, valid_topic_ids=["atomkraft"])
+
+
+def test_duplicate_question_id_rejected(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+topics:
+  atomkraft:
+    - id: dup
+      text: "A"
+      query: "a"
+  klima:
+    - id: dup
+      text: "B"
+      query: "b"
+""",
+    )
+    with pytest.raises(QuestionRegistryError, match="duplicate question id"):
+        load_questions(path, valid_topic_ids=["atomkraft", "klima"])
+
+
+def test_duplicate_query_rejected(tmp_path: Path) -> None:
+    """watches.query is UNIQUE — two questions sharing a query would collide."""
+    path = _write(
+        tmp_path,
+        """
+topics:
+  atomkraft:
+    - id: q1
+      text: "A"
+      query: "Nuclear Power"
+  klima:
+    - id: q2
+      text: "B"
+      query: "nuclear power"
+""",
+    )
+    with pytest.raises(QuestionRegistryError, match="duplicate query"):
+        load_questions(path, valid_topic_ids=["atomkraft", "klima"])
+
+
+def test_empty_field_rejected(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+topics:
+  atomkraft:
+    - id: q1
+      text: "  "
+      query: "a"
+""",
+    )
+    with pytest.raises(QuestionRegistryError):
+        load_questions(path, valid_topic_ids=["atomkraft"])
+
+
+def test_missing_file_raises(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        load_questions(tmp_path / "nope.yml")
+
+
+def test_topic_not_a_list_rejected(tmp_path: Path) -> None:
+    path = _write(
+        tmp_path,
+        """
+topics:
+  atomkraft:
+    id: q1
+""",
+    )
+    with pytest.raises(QuestionRegistryError, match="list of questions"):
+        load_questions(path, valid_topic_ids=["atomkraft"])
+
+
+# ---------------------------------------------------------------------------
+# watch_spec_for — pure, deterministic
+# ---------------------------------------------------------------------------
+
+def test_watch_spec_deterministic_and_labeled() -> None:
+    q = Question(
+        id="q1", topic_id="atomkraft",
+        text="Keep nuclear power?", query="nuclear power", since_year=2020,
+    )
+    spec1 = watch_spec_for(q, topic_name="Atomkraft")
+    spec2 = watch_spec_for(q, topic_name="Atomkraft")
+    assert spec1 == spec2  # deterministic → idempotent sync
+    assert spec1["query"] == "nuclear power"
+    assert spec1["label"] == "Atomkraft: Keep nuclear power?"
+    assert spec1["since_year"] == 2020
+
+
+def test_watch_label_falls_back_to_topic_id() -> None:
+    q = Question(id="q1", topic_id="atomkraft", text="X?", query="x")
+    assert q.watch_label() == "atomkraft: X?"
+
+
+# ---------------------------------------------------------------------------
+# The shipped registry must be consistent with the shipped topics
+# ---------------------------------------------------------------------------
+
+def test_shipped_registry_is_valid() -> None:
+    settings = get_settings()
+    topic_ids = [t.id for t in load_topics(settings.topics_csv_path)]
+    qs = load_questions(settings.questions_yaml_path, valid_topic_ids=topic_ids)
+    assert qs, "shipped questions.yml should not be empty"
+    # ids + queries unique is enforced by the loader; assert FK coverage too.
+    assert all(q.topic_id in topic_ids for q in qs)
+
+
+# ---------------------------------------------------------------------------
+# CLI — registration + offline list over the shipped registry
+# ---------------------------------------------------------------------------
+
+def test_cli_questions_registered() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["questions", "--help"])
+    assert result.exit_code == 0
+    out = _plain(result.output)
+    assert "sync" in out and "answer" in out and "list" in out
+
+
+def test_cli_questions_list_offline() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["questions", "list"])
+    assert result.exit_code == 0
+    out = _plain(result.output)
+    assert "atomkraft" in out
+    assert "nuclear power" in out
+
+
+def test_cli_questions_list_filter_topic() -> None:
+    runner = CliRunner()
+    result = runner.invoke(app, ["questions", "list", "--topic", "verteidigung"])
+    assert result.exit_code == 0
+    out = _plain(result.output)
+    assert "verteidigung" in out
+    assert "atomkraft" not in out
+
+
+# ---------------------------------------------------------------------------
+# Integration (real Postgres) — sync idempotency
+# ---------------------------------------------------------------------------
+
+pytestmark_integration = pytest.mark.skipif(
+    not TEST_DSN, reason="STUDY_SCRAPER_TEST_DSN not set; skipping integration"
+)
+
+
+@pytest.fixture(scope="module")
+def storage():
+    from study_scraper.storage import PostgresStorage
+    assert TEST_DSN is not None
+    store = PostgresStorage(TEST_DSN)
+    store.migrate()
+    return store
+
+
+@pytestmark_integration
+def test_sync_is_idempotent(storage) -> None:
+    with storage.connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute("TRUNCATE study_scraper.watch_snapshots CASCADE")
+            cur.execute("TRUNCATE study_scraper.watches CASCADE")
+        conn.commit()
+
+    settings = get_settings()
+    topic_ids = [t.id for t in load_topics(settings.topics_csv_path)]
+    registry = load_questions(
+        settings.questions_yaml_path, valid_topic_ids=topic_ids
+    )
+
+    def _sync() -> None:
+        for q in registry:
+            spec = watch_spec_for(q)
+            storage.add_watch(
+                query=str(spec["query"]),
+                label=str(spec["label"]),
+                since_year=spec["since_year"],
+            )
+
+    _sync()
+    first = storage.list_watches()
+    _sync()  # re-sync must not duplicate
+    second = storage.list_watches()
+
+    assert len(first) == len(registry)
+    assert len(second) == len(registry)
+    assert {w["query"] for w in first} == {w["query"] for w in second}


### PR DESCRIPTION
## What

Hotfix for a regression introduced by #43. `study_scraper/http.py` imports `tenacity`, and every source client (+ `fulltext`) imports `http`, so `python -m study_scraper …` and `pytest tests/study_scraper` now fail at **import time** with `ModuleNotFoundError: No module named 'tenacity'` unless tenacity is installed.

The workflows install a hand-picked package list (not `requirements.txt`), and none listed `tenacity`. This turned the **Jul 9 `scheduled-scrape` RED at the migrate step** (run #12 — instant import failure; run #11 on Jul 6 was green, *before* #43 merged), and would break CI, `attribute`, and the agent workflows the same way once they run.

## Fix

Add `tenacity` to every workflow that imports `study_scraper`:
`scrape`, `attribute`, `ci-study-scraper`, `agent-develop`, `agent-review`, `agent-product`, `agent-monitor`.

## Verify

- Confirmed all 7 install blocks now include `tenacity`; no `study_scraper`-importing workflow is missed.
- `import study_scraper.cli` succeeds locally with tenacity present.
- Root cause matches the failure signature exactly: #12 died in <1s at "Migrate schema" with all downstream steps skipped; the DB-secret gate passed, so it was not the token — it was an import error.

## Note

This does not touch the token issue (#24) — that's independent. This restores the **crawl** pipeline, which needs no Claude credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b

---
_Generated by [Claude Code](https://claude.ai/code/session_01JW3th6GFshnUDxu9P6U34b)_